### PR TITLE
Prevent RatingModal draft resets on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Fixed personal rating modal (`RatingModal`) resetting its draft state to the database ratings when background metadata updates or library refreshes occur while the modal is open.
 - Fixed rating displays on library and catalog card overviews to format consistently on the 0–10 scale (`/10`), resolving an issue where ratings at or below 5 were mislabeled with a `/5` denominator (#321).
 - The browser extension still did not reach disk after the previous fix. That fix was correct as far as it went -- `asarUnpack` put the files at `resources\\app.asar.unpacked\\extension` and the candidate ordering found them -- and the copy then failed at the DESTINATION, which nothing had looked at.
 - `ensureExtensionFiles` targeted `path.join(appDataRoot, 'extension')`, and on Windows `appDataRoot` IS the install directory: `dataLocation.js` `resolveDataRoot` returns `installDir` on win32. So the target was `C:\\Program Files\\Atlas\\extension`, and every copy failed with EPERM.

--- a/src/components/detail/RatingModal.jsx
+++ b/src/components/detail/RatingModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   PERSONAL_RATING_CATEGORIES,
   RATING_MAX,
@@ -23,15 +23,26 @@ export default function RatingModal({
   onCancel,
 }) {
   const [draft, setDraft] = useState({})
+  const prevOpenRef = useRef(false)
+  const prevTitleRef = useRef(title)
 
+  // Initialise the draft ONLY when the modal transitions from closed to open or
+  // switches to a different title. Listening to prop changes directly while open
+  // caused background metadata/library refreshes (which pass a new `ratings` prop
+  // object reference) to overwrite the user's uncommitted slider adjustments.
   useEffect(() => {
-    if (!open) return
-    setDraft(
-      Object.fromEntries(
-        PERSONAL_RATING_CATEGORIES.map(({ key }) => [key, Number(ratings?.[key]) || 0]),
-      ),
-    )
-  }, [open, ratings])
+    const justOpened = open && !prevOpenRef.current
+    const titleChanged = open && prevTitleRef.current !== title
+    if (justOpened || titleChanged) {
+      setDraft(
+        Object.fromEntries(
+          PERSONAL_RATING_CATEGORIES.map(({ key }) => [key, Number(ratings?.[key]) || 0]),
+        ),
+      )
+    }
+    prevOpenRef.current = Boolean(open)
+    prevTitleRef.current = title
+  }, [open, title, ratings])
 
   if (!open) return null
 

--- a/tests/rating-system.test.js
+++ b/tests/rating-system.test.js
@@ -1,4 +1,6 @@
-import { test, expect } from 'vitest'
+// @vitest-environment jsdom
+import { test, expect, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import fs from 'fs'
 import path from 'path'
 import {
@@ -7,7 +9,11 @@ import {
   computeOnlineRating as uiOnline,
 } from '../src/utils/ratingCategories.js'
 import { resolveBannerField } from '../src/components/library/bannerLayout/bannerFieldResolvers.js'
+import React from 'react'
+import RatingModal from '../src/components/detail/RatingModal.jsx'
 const db = require('../electron/db/ratingCategories.js')
+
+afterEach(() => cleanup())
 
 // Main is CommonJS and the renderer an ESM bundle, so the category list is
 // duplicated. If the two drift, the modal writes keys the database has no columns
@@ -140,4 +146,37 @@ test('banner layout rating fields format on the 0-10 scale even when rating is b
   const f95Low = resolveBannerField('sourceRating', { rating: 2.2 })
   expect(f95Low.value).toBe('4.4/10')
   expect(f95Low.value).not.toContain('/5')
+})
+
+test('RatingModal preserves unsaved draft ratings when background metadata update passes fresh ratings prop', () => {
+  const initialRatings = { story: 2, graphics: 3 }
+  const { rerender } = render(
+    React.createElement(RatingModal, {
+      open: true,
+      title: 'Test Game',
+      ratings: initialRatings,
+      onSave: () => {},
+      onCancel: () => {},
+    }),
+  )
+
+  // User moves the Story slider to 8 while modal is open.
+  const storyInput = screen.getByRole('slider', { name: 'Story' })
+  fireEvent.change(storyInput, { target: { value: '8' } })
+  expect(storyInput.value).toBe('8')
+
+  // Background metadata update finishes and passes a new ratings object reference to RatingModal.
+  const refreshedRatings = { story: 2, graphics: 3 }
+  rerender(
+    React.createElement(RatingModal, {
+      open: true,
+      title: 'Test Game',
+      ratings: refreshedRatings,
+      onSave: () => {},
+      onCancel: () => {},
+    }),
+  )
+
+  // The draft rating set by the user (8) should NOT be reset back to the initial saved rating (2).
+  expect(screen.getByRole('slider', { name: 'Story' }).value).toBe('8')
 })


### PR DESCRIPTION
## What this changes

Prevents the personal rating modal (`RatingModal`) from resetting active, unsaved rating slider adjustments when background metadata updates or library refreshes pass a fresh `ratings` prop reference while the modal is open.

## Why

- **User-visible symptom**: When a user was actively adjusting category sliders in `RatingModal`, triggering or running a background metadata update caused the sliders to reset back to their last saved status in the database.
- **Root cause**: `RatingModal.jsx` had a `useEffect` with dependency array `[open, ratings]`. Whenever background updates refreshed the game object in `App.jsx` and `GameDetailPage.jsx`, `readRatingsFromGame(game)` returned a new `ratings` object reference. Because `ratings` was in the dependency array, `useEffect` re-fired while `open === true` and called `setDraft(...)` with the database ratings, wiping the user's uncommitted slider edits.

## How it was tested

- Added regression test `RatingModal preserves unsaved draft ratings when background metadata update passes fresh ratings prop` in `tests/rating-system.test.js`.
- Verified that the regression test **FAILED** against the unfixed code with `AssertionError: expected '2' to be '8'` before the fix, and **PASSED** after adding the ref transition guards.

- [x] Added tests that cover this change
- [x] For a fix: the regression test fails against the unfixed code
- [x] `npm run check` passes locally
- [x] New functions and IPC handlers have comments explaining *why*
- [x] `CHANGELOG.md` updated
- [x] This PR targets `nightly`, not `main`


## Anything the reviewer should know

- Used `useRef` tracking (`prevOpenRef` and `prevTitleRef`) in `RatingModal.jsx` so `setDraft(...)` is executed strictly when the modal transitions from closed to open or when switching to a different title.
- Audited all other modal and form components (`CollectionModal`, `BulkTagModal`, `RefreshMediaModal`, `UpdateModal`, `TagEditor`) and confirmed that `RatingModal` was the only component where uncommitted draft state was being overwritten by background domain updates.
