### PR TITLE
fix: add missing engine and f95Id field  when setting library install…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Fixed missing {engine} and {f95Id} for downloads-install handler. Previously it only work during nomral importer, but shown Unknown or empty when set in Atlas Library Structure during downloads-install process. 
 - Fixed personal rating modal (`RatingModal`) resetting its draft state to the database ratings when background metadata updates or library refreshes occur while the modal is open.
 - Fixed rating displays on library and catalog card overviews to format consistently on the 0–10 scale (`/10`), resolving an issue where ratings at or below 5 were mislabeled with a `/5` denominator (#321).
 - The browser extension still did not reach disk after the previous fix. That fix was correct as far as it went -- `asarUnpack` put the files at `resources\\app.asar.unpacked\\extension` and the candidate ordering found them -- and the copy then failed at the DESTINATION, which nothing had looked at.

--- a/electron/ipc/importer.js
+++ b/electron/ipc/importer.js
@@ -4684,11 +4684,14 @@ ipcMain.handle("downloads-install", async (event, { id, version, onComplete, kee
 
     // Same layout as a normal import, so downloads and imports are
     // indistinguishable on disk.
+    // console.log('[downloads-install] record:', JSON.stringify(record, null, 2));
     const targetBase = getUniquePath(
       buildStructuredImportPath(
         targetLibrary,
         currentConfig?.Library?.libraryFolderStructure,
         {
+          f95Id: record.f95_id || record.f95Id || "",
+          engine: record.engine || "Unknown",
           creator: record.creator,
           title: record.title,
           version: finalVersion,

--- a/tests/importer-helpers.test.js
+++ b/tests/importer-helpers.test.js
@@ -9,6 +9,7 @@ import fs from 'fs'
 
 
 const { __testables: T } = require('../electron/ipc/importer')
+const acorn = require('acorn')
 
 describe('sanitizePathSegment', () => {
   it('replaces filesystem-illegal characters', () => {
@@ -81,25 +82,50 @@ describe('buildStructuredImportPath', () => {
 })
 
 
-// Strip comments and console.log calls to use with test that based on code availability scanning
-function stripCommentsAndLog(src) {
-  return src
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/\/\/[^\n]*/g, '')
-    .replace(/console\.log\([^)]*\);/g, '');
+// walks the ast looking for a call expression that matches. returns first hit
+function findCall(node, matcher) {
+  if (!node || typeof node.type !== 'string') return null
+  if (node.type === 'CallExpression' && matcher(node)) return node
+
+  for (const key in node) {
+    const val = node[key]
+    if (Array.isArray(val)) {
+      for (const child of val) {
+        const hit = findCall(child, matcher)
+        if (hit) return hit
+      }
+    } else if (val && typeof val === 'object') {
+      const hit = findCall(val, matcher)
+      if (hit) return hit
+    }
+  }
+  return null
 }
 
-test('downloads-install allows supported fields in Atlas Library Structure path regex', () => {
+test('downloads-install passes required fields in buildStructuredImportPath', () => {
   const src = fs.readFileSync(path.join(__dirname, '..', 'electron', 'ipc', 'importer.js'), 'utf8')
-  const clean = stripCommentsAndLog(src)
-  const s = clean.slice(clean.indexOf('ipcMain.handle("downloads-install"'))
-  const t = s.slice(s.indexOf('const targetBase = getUniquePath('))
-  const b = t.slice(0, t.indexOf('buildStructuredImportPath(') + 600)
-  expect(b).toMatch(/f95Id\s*:/)
-  expect(b).toMatch(/engine\s*:/)
-  expect(b).toMatch(/creator\s*:/)
-  expect(b).toMatch(/title\s*:/)
-  expect(b).toMatch(/version\s*:/)
+  const ast = acorn.parse(src, { ecmaVersion: 'latest' })
+
+  const isDownloadsInstallHandle = (node) =>
+    node.callee?.object?.name === 'ipcMain' &&
+    node.callee?.property?.name === 'handle' &&
+    node.arguments[0]?.value === 'downloads-install'
+
+  const handlerCall = findCall(ast, isDownloadsInstallHandle)
+  if (!handlerCall) throw new Error('ipcMain.handle("downloads-install", ...) not found')
+
+  const buildCall = findCall(handlerCall, (n) => n.callee?.name === 'buildStructuredImportPath')
+  if (!buildCall) throw new Error('buildStructuredImportPath not called inside downloads-install handler')
+
+  const obj = buildCall.arguments.find((a) => a.type === 'ObjectExpression')
+  if (!obj) throw new Error('buildStructuredImportPath was not given an object literal')
+
+  const keys = obj.properties.map((p) => p.key.name)
+  const required = ['f95Id', 'engine', 'creator', 'title', 'version']
+
+  for (const key of required) {
+    expect(keys).toContain(key)
+  }
 })
 
 describe('source detection — Steam', () => {

--- a/tests/importer-helpers.test.js
+++ b/tests/importer-helpers.test.js
@@ -5,6 +5,8 @@
 
 import { describe, it, expect } from 'vitest'
 import path from 'path'
+import fs from 'fs'
+
 
 const { __testables: T } = require('../electron/ipc/importer')
 
@@ -76,6 +78,28 @@ describe('buildStructuredImportPath', () => {
     const out = T.buildStructuredImportPath('/lib', '{lcid}', { lcId: 'LC9' })
     expect(out).toBe(path.join('/lib', 'LC9'))
   })
+})
+
+
+// Strip comments and console.log calls to use with test that based on code availability scanning
+function stripCommentsAndLog(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/console\.log\([^)]*\);/g, '');
+}
+
+test('downloads-install allows supported fields in Atlas Library Structure path regex', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'electron', 'ipc', 'importer.js'), 'utf8')
+  const clean = stripCommentsAndLog(src)
+  const s = clean.slice(clean.indexOf('ipcMain.handle("downloads-install"'))
+  const t = s.slice(s.indexOf('const targetBase = getUniquePath('))
+  const b = t.slice(0, t.indexOf('buildStructuredImportPath(') + 600)
+  expect(b).toMatch(/f95Id\s*:/)
+  expect(b).toMatch(/engine\s*:/)
+  expect(b).toMatch(/creator\s*:/)
+  expect(b).toMatch(/title\s*:/)
+  expect(b).toMatch(/version\s*:/)
 })
 
 describe('source detection — Steam', () => {


### PR DESCRIPTION
## What this changes

Currently the description of Atlas Library Structure is "Used when imports are moved or archives are extracted into the default library folder. Options: {creator}, {title}, {version}, {engine}, {f95Id}." However, when using download - install feature with such said regex, the {engine} and {f95Id} are not currently working, resulting in "Unknown" or empty id.

## Why
The downloads-install handler build the importer path currently with just creator, title and version.

## How it was tested
- [x] Added tests that cover this change
- [x] For a fix: the regression test fails against the unfixed code -- It failed against added test when the field is missing
- [x] `npm run check` passes locally -- 1 error from existing nightly mega-host.test.js × derives a v1 key deterministically
- [x] New functions and IPC handlers have comments explaining *why*
- [x] `CHANGELOG.md` updated
- [x] This PR targets `nightly`, not `main`

Added new test in importer-helpers.test.js 
```
npx vitest run tests/importer-helpers.test.js -t "downloads-install passes required fields in buildStructuredImportPath"
...
✓ downloads-install passes required fields in buildStructuredImportPath
```

## AI assistance
- [x] No AI was used on this change

## Anything the reviewer should know
- Since the change is minor but it involves the code that is in a handler integration that have multiple parts, I didn't find a reference of an similar integration test / mock that I can quickly add in, so i opted for adding a dumb code scan instead to make sure these field persist in case it was removed upon merging. If there is a better and proper approach feel free to edit so I can reference it in future.
