### PR TITLE
[ATLAS-339] fix: migrate keyboard control effect to PreviewLightBox to apply all lightbox control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Update global lightbox control for media in lightbox instead of only under GameDetails.
 - Fixed browser extension thread matching comparing numeric IDs across sites without validating the host domain source (F95Zone vs LewdCorner). F95Zone threads with ID `X` were erroneously matched against games that only carried LewdCorner ID `X`. Thread lookup is now strictly site-isolated (`f95Id` for F95Zone threads, `lcId` for LewdCorner threads).
 - Fixed `open-game-folder` IPC handler opening the parent directory of the game folder instead of the game directory itself (`selectedVersion.game_path`).
 - "Open Game Folder" was missing entirely from the context menu of every Steam and GOG title, and so was Play. Both rows were built from one list filtered as `versions.filter(v => v.exec_path && v.hasExecutable !== false)`, and Steam and GOG versions are stored with an EMPTY `exec_path` by design -- they launch through `steam://run` and `goggalaxy://openGameView`, see the `upsertVersion` calls in `electron/ipc/importer.js`. So the filter removed those titles before either row existed. The submenu was correct; nothing ever reached it.

--- a/src/components/detail/GameDetailPage.jsx
+++ b/src/components/detail/GameDetailPage.jsx
@@ -490,17 +490,6 @@ const GameDetailPage = ({ game, onBack, onRefresh, onWishlistChanged, openRating
     else rootRef.current?.scrollIntoView?.({ block: 'start' })
   }, [game?.record_id])
 
-  useEffect(() => {
-    if (lightboxIndex === null) return
-    const onKey = (e) => {
-      if (e.key === 'Escape') setLightboxIndex(null)
-      else if (e.key === 'ArrowLeft') setLightboxIndex((i) => (i === null ? i : (i - 1 + previews.length) % previews.length))
-      else if (e.key === 'ArrowRight') setLightboxIndex((i) => (i === null ? i : (i + 1) % previews.length))
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [lightboxIndex, previews.length])
-
   // ── Banner feathering ─────────────────────────────────────────────────────
   const recomputeFeather = () => {
     const c = bannerRef.current

--- a/src/components/detail/page/PreviewLightbox.jsx
+++ b/src/components/detail/page/PreviewLightbox.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import SafeImage from '../../ui/SafeImage.jsx'
 import DashVideo from './DashVideo.jsx'
 import { toMediaSrc } from '../../../utils/mediaSrc.js'
@@ -42,6 +42,20 @@ export default function PreviewLightbox({ previews, lightboxIndex, onClose, onPr
 
   // Reset measured size whenever the displayed media changes.
   useEffect(() => { setNatural(null) }, [key])
+
+  // Migrate the navigation callbacks from GameDetails to here to control all lightbox navigation
+  const navRef = useRef({ onClose, onPrev, onNext })
+  navRef.current = { onClose, onPrev, onNext }
+  useEffect(() => {
+    if (lightboxIndex === null) return
+    const onKey = (e) => {
+      if (e.key === 'Escape') navRef.current.onClose()
+      else if (e.key === 'ArrowLeft') navRef.current.onPrev()
+      else if (e.key === 'ArrowRight') navRef.current.onNext()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [lightboxIndex, previews.length])
 
   if (lightboxIndex === null || !previews[lightboxIndex]) return null
 

--- a/tests/preview-lightbox-keyboard.test.jsx
+++ b/tests/preview-lightbox-keyboard.test.jsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+import PreviewLightbox from '../src/components/detail/page/PreviewLightbox.jsx'
+
+afterEach(() => cleanup())
+
+describe('PreviewLightbox keyboard navigation', () => {
+  const openLightbox = () => {
+    const onClose = vi.fn()
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    render(
+      <PreviewLightbox
+        previews={['a.png', 'b.png', 'c.png']}
+        lightboxIndex={0}
+        onClose={onClose}
+        onPrev={onPrev}
+        onNext={onNext}
+      />,
+    )
+    return { onClose, onPrev, onNext }
+  }
+
+  it('renders nothing when closed', () => {
+    render(
+      <PreviewLightbox
+        previews={['a.png']}
+        lightboxIndex={null}
+        onClose={vi.fn()}
+        onPrev={vi.fn()}
+        onNext={vi.fn()}
+      />,
+    )
+    expect(screen.queryByTitle('Close (Esc)')).toBeNull()
+  })
+
+  it('calls onNext on ArrowRight while open', () => {
+    const { onNext } = openLightbox()
+    fireEvent.keyDown(window, { key: 'ArrowRight' })
+    expect(onNext).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onPrev on ArrowLeft while open', () => {
+    const { onPrev } = openLightbox()
+    fireEvent.keyDown(window, { key: 'ArrowLeft' })
+    expect(onPrev).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose on Escape while open', () => {
+    const { onClose } = openLightbox()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not respond to keys when closed', () => {
+    const onClose = vi.fn()
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    render(
+      <PreviewLightbox
+        previews={['a.png']}
+        lightboxIndex={null}
+        onClose={onClose}
+        onPrev={onPrev}
+        onNext={onNext}
+      />,
+    )
+    fireEvent.keyDown(window, { key: 'ArrowRight' })
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onNext).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('removes its window listener when unmounted while open', () => {
+    // A listener surviving unmount calls setState on a dead component — the
+    // window listener path here mirrors the document-listener assertion in
+    // split-button-menu.test.jsx.
+    const remove = vi.spyOn(window, 'removeEventListener')
+    const { unmount } = render(
+      <PreviewLightbox
+        previews={['a.png']}
+        lightboxIndex={0}
+        onClose={vi.fn()}
+        onPrev={vi.fn()}
+        onNext={vi.fn()}
+      />,
+    )
+    unmount()
+    const removed = remove.mock.calls.map((call) => call[0])
+    expect(removed).toContain('keydown')
+    remove.mockRestore()
+  })
+})


### PR DESCRIPTION
## What this changes
Move the control in GameDetails for media control to PreviewLightBox for global lightbox control

## Why
Existing issue: https://github.com/towerwatchman/Atlas/issues/339

## How it was tested
- [x] Added tests that cover this change
- [x] For a fix: the regression test fails against the unfixed code
- [x] `npm run check` passes locally
- [x] New functions and IPC handlers have comments explaining *why*
- [x] `CHANGELOG.md` updated
- [x] This PR targets `nightly`, not `main`

## AI assistance
- [ ] No AI was used on this change
- [x] AI was used on this change

**Tool and model:** OpenCode's Big Pickle - Debug + Generate Test

**What it wrote:**
tests\preview-lightbox-keyboard.test.jsx

**What you verified yourself:** 
- Verified the change works on GameDetails page + GameDetails -> Properties -> Media page for control works while it didn't before the change.
- Verified the specific test pass, no new lint issue, and npm run check didn't generate new error

```
Before:
  Test Files  2 failed | 71 passed (73)
  Tests  11 failed | 898 passed | 7 skipped (916)

After:
  Test Files  2 failed | 72 passed (74)
  Tests  11 failed | 904 passed | 7 skipped (922)
``` 