### PR TITLE
fix: exclude unrated categories from Personal Rating calculation on GameDetails page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Fixed the PersonalRating display in GameDetailsPage to exclude unrated categories.
 - Update global lightbox control for media in lightbox instead of only under GameDetails.
 - Fixed browser extension thread matching comparing numeric IDs across sites without validating the host domain source (F95Zone vs LewdCorner). F95Zone threads with ID `X` were erroneously matched against games that only carried LewdCorner ID `X`. Thread lookup is now strictly site-isolated (`f95Id` for F95Zone threads, `lcId` for LewdCorner threads).
 - Fixed `open-game-folder` IPC handler opening the parent directory of the game folder instead of the game directory itself (`selectedVersion.game_path`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixed
-- Fixed the PersonalRating display in GameDetailsPage to exclude unrated categories.
+- Fixed the Personal Rating on the game detail page counting unrated categories as a score of zero, which dragged the average down (rating two categories 8 and 6 showed 1.75 rather than 7) and disagreed with the figure `RatingModal` displayed for the same game. The page had a private copy of the averaging rule; it now calls the shared `computeRatingAverage` it was already importing, so the detail page, the rating modal and the database all apply one rule.
 - Update global lightbox control for media in lightbox instead of only under GameDetails.
 - Fixed browser extension thread matching comparing numeric IDs across sites without validating the host domain source (F95Zone vs LewdCorner). F95Zone threads with ID `X` were erroneously matched against games that only carried LewdCorner ID `X`. Thread lookup is now strictly site-isolated (`f95Id` for F95Zone threads, `lcId` for LewdCorner threads).
 - Fixed `open-game-folder` IPC handler opening the parent directory of the game folder instead of the game directory itself (`selectedVersion.game_path`).

--- a/src/components/detail/GameDetailPage.jsx
+++ b/src/components/detail/GameDetailPage.jsx
@@ -61,17 +61,6 @@ const getPersonalRatingsPayload = (draft = {}) =>
     ]),
   )
 
-const getPersonalRatingsOverall = (draft = {}) => {
-  const values = Object.values(getPersonalRatingsPayload(draft))
-    .filter((value) => Number.isFinite(value) && value > 0)
-  if (values.length === 0) return null
-  const average = values.reduce((sum, value) => sum + value, 0) / values.length
-  return Math.round(average * 10) / 10
-}
-
-// export for tests/rating-system.test.js
-export { getPersonalRatingsOverall }
-
 const splitPreviewUrls = (value) => {
   if (Array.isArray(value)) return value.map((url) => String(url || '').trim()).filter(Boolean)
   return String(value || '').split(',').map((url) => url.trim()).filter(Boolean)
@@ -734,7 +723,11 @@ const GameDetailPage = ({ game, onBack, onRefresh, onWishlistChanged, openRating
 
   const externalLinks = buildGameLinks(game)
   const personalRatingsDirty = JSON.stringify(personalRatingsDraft) !== JSON.stringify(personalRatingsSaved)
-  const personalRatingsOverall = getPersonalRatingsOverall(personalRatingsDraft)
+  // Shared with RatingModal and electron/db/ratingCategories.js rather than
+  // averaged here, because a private copy is exactly how this diverged: the
+  // local one counted an unrated 0 as a score of zero and dragged the average
+  // down, so the page and the modal open on top of it disagreed.
+  const personalRatingsOverall = computeRatingAverage(personalRatingsDraft)
 
   // While viewing an uninstalled Steam game, poll every 15s to see if Steam has
   // finished installing it (e.g. after the Install button handed off to Steam).
@@ -1823,4 +1816,3 @@ const GameDetailPage = ({ game, onBack, onRefresh, onWishlistChanged, openRating
 }
 
 export default GameDetailPage
-

--- a/src/components/detail/GameDetailPage.jsx
+++ b/src/components/detail/GameDetailPage.jsx
@@ -63,11 +63,14 @@ const getPersonalRatingsPayload = (draft = {}) =>
 
 const getPersonalRatingsOverall = (draft = {}) => {
   const values = Object.values(getPersonalRatingsPayload(draft))
-    .filter((value) => Number.isFinite(value))
+    .filter((value) => Number.isFinite(value) && value > 0)
   if (values.length === 0) return null
   const average = values.reduce((sum, value) => sum + value, 0) / values.length
   return Math.round(average * 10) / 10
 }
+
+// export for tests/rating-system.test.js
+export { getPersonalRatingsOverall }
 
 const splitPreviewUrls = (value) => {
   if (Array.isArray(value)) return value.map((url) => String(url || '').trim()).filter(Boolean)
@@ -1820,3 +1823,4 @@ const GameDetailPage = ({ game, onBack, onRefresh, onWishlistChanged, openRating
 }
 
 export default GameDetailPage
+

--- a/tests/rating-system.test.js
+++ b/tests/rating-system.test.js
@@ -8,7 +8,6 @@ import {
   computeRatingAverage as uiAverage,
   computeOnlineRating as uiOnline,
 } from '../src/utils/ratingCategories.js'
-import { getPersonalRatingsOverall } from '../src/components/detail/GameDetailPage.jsx'
 import { resolveBannerField } from '../src/components/library/bannerLayout/bannerFieldResolvers.js'
 import React from 'react'
 import RatingModal from '../src/components/detail/RatingModal.jsx'
@@ -60,17 +59,6 @@ test('the renderer average agrees with the database average', () => {
   ]) {
     expect(uiAverage(sample)).toBe(db.computeRatingAverage(sample))
   }
-})
-
-// getPersonalRatingsOverall ignores zero ratings when calculating average
-test('getPersonalRatingsOverall ignores zero ratings', () => {
-  expect(getPersonalRatingsOverall({})).toBeNull()
-  expect(getPersonalRatingsOverall({ story: 0, graphics: 0, gameplay: 0 })).toBeNull()
-  expect(getPersonalRatingsOverall({
-    story: 9, graphics: 9, gameplay: 9,
-    characters: 0, sound: 0, writing: 0, polish: 0, replayability: 0,
-  })).toBe(9)
-  expect(getPersonalRatingsOverall({ story: 8, graphics: 6 })).toBe(7)
 })
 
 test('values are clamped to 0-10 and rounded', () => {
@@ -126,6 +114,23 @@ test('the detail page shows both ratings and defaults to Unrated', () => {
   expect(page).toContain('Personal Rating')
   expect(page).toContain('<RatingModal')
   expect(page).toMatch(/'Unrated'/)
+})
+
+// The detail page had its own copy of the averaging rule, and the copy was the
+// one missing the > 0 clause -- so an unrated category counted as a score of
+// zero and dragged the Personal Rating down, while RatingModal (which already
+// called the shared function) showed a different number for the same game.
+// electron/db/versions.js resolved the same divergence the same way. Asserted
+// as text because GameDetailPage cannot be mounted, matching the test above.
+test('the detail page averages through the shared function, not a private copy', () => {
+  const page = fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'components', 'detail', 'GameDetailPage.jsx'),
+    'utf8',
+  )
+  expect(page).toContain('computeRatingAverage(personalRatingsDraft)')
+  expect(page).not.toMatch(/const getPersonalRatingsOverall/)
+  // The save path still needs its own normaliser; only the averaging moved.
+  expect(page).toContain('const getPersonalRatingsPayload')
 })
 
 // Menu construction moved out of GameBanner into the shared builder when the
@@ -192,4 +197,3 @@ test('RatingModal preserves unsaved draft ratings when background metadata updat
   // The draft rating set by the user (8) should NOT be reset back to the initial saved rating (2).
   expect(screen.getByRole('slider', { name: 'Story' }).value).toBe('8')
 })
-

--- a/tests/rating-system.test.js
+++ b/tests/rating-system.test.js
@@ -8,6 +8,7 @@ import {
   computeRatingAverage as uiAverage,
   computeOnlineRating as uiOnline,
 } from '../src/utils/ratingCategories.js'
+import { getPersonalRatingsOverall } from '../src/components/detail/GameDetailPage.jsx'
 import { resolveBannerField } from '../src/components/library/bannerLayout/bannerFieldResolvers.js'
 import React from 'react'
 import RatingModal from '../src/components/detail/RatingModal.jsx'
@@ -59,6 +60,17 @@ test('the renderer average agrees with the database average', () => {
   ]) {
     expect(uiAverage(sample)).toBe(db.computeRatingAverage(sample))
   }
+})
+
+// getPersonalRatingsOverall ignores zero ratings when calculating average
+test('getPersonalRatingsOverall ignores zero ratings', () => {
+  expect(getPersonalRatingsOverall({})).toBeNull()
+  expect(getPersonalRatingsOverall({ story: 0, graphics: 0, gameplay: 0 })).toBeNull()
+  expect(getPersonalRatingsOverall({
+    story: 9, graphics: 9, gameplay: 9,
+    characters: 0, sound: 0, writing: 0, polish: 0, replayability: 0,
+  })).toBe(9)
+  expect(getPersonalRatingsOverall({ story: 8, graphics: 6 })).toBe(7)
 })
 
 test('values are clamped to 0-10 and rounded', () => {
@@ -180,3 +192,4 @@ test('RatingModal preserves unsaved draft ratings when background metadata updat
   // The draft rating set by the user (8) should NOT be reset back to the initial saved rating (2).
   expect(screen.getByRole('slider', { name: 'Story' }).value).toBe('8')
 })
+


### PR DESCRIPTION
## What this changes
Personal Ratings now correctly exclude unrated categories from average calculation

## Why
<img width="457" height="472" alt="image" src="https://github.com/user-attachments/assets/33dd2e6f-e6ac-4467-840e-cac183381697" />
<img width="334" height="68" alt="image" src="https://github.com/user-attachments/assets/e44223a7-a398-4d83-9dec-8bd5843f36c0" />
<img width="168" height="40" alt="image" src="https://github.com/user-attachments/assets/0c1db416-d5be-4a46-9fb4-c7d0bb6d3cbe" />


## How it was tested
- [x] Added tests that cover this change
- [x] Verified the GUI in dev env
- [x] For a fix: the regression test fails against the unfixed code
- [x] `npm run check` passes locally
- [x] New functions and IPC handlers have comments explaining *why*
- [x] `CHANGELOG.md` updated
- [x] This PR targets `nightly`, not `main`

```
❯ npx vitest run tests/rating-system.test.js -t 'getPersonalRatingsOverall'

 RUN  v4.1.10 P:/dev/projects/collab/Atlas

 ✓ tests/rating-system.test.js (15 tests | 14 skipped) 6ms
   ✓ getPersonalRatingsOverall ignores zero ratings 2ms

 Test Files  1 passed (1)
      Tests  1 passed | 14 skipped (15)

---

BEFORE:
 Test Files  1 failed | 79 passed (80)
 Tests  2 failed | 989 passed | 7 skipped (998)

AFTER:
 Test Files  1 failed | 79 passed (80)
 Tests  2 failed | 990 passed | 7 skipped (999)
```

<img width="400" height="400" alt="electron_uGRYPbK94B" src="https://github.com/user-attachments/assets/5f32cb99-d02c-4633-bac4-1e524be57d0f" />

<img width="300" height="60" alt="electron_wRabH6Oddm" src="https://github.com/user-attachments/assets/e6313ce0-84d1-4c3f-8188-d5f5e24587e8" />


## AI assistance
- [x] No AI was used on this change
- [ ] AI was used on this change

