### PR TITLE
refactor: remove 'has Steam map' filter, as well as refactor common ui and templates for QuickFilters section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ### Fixed
+- Modify Quick Filter Section to not appear when there is no filter, and do an initial refactor on SearchSidebar for this section
+- Remove the 'has Steam mapping' quick filter 
 - Update global lightbox control for media in lightbox instead of only under GameDetails.
 - Fixed browser extension thread matching comparing numeric IDs across sites without validating the host domain source (F95Zone vs LewdCorner). F95Zone threads with ID `X` were erroneously matched against games that only carried LewdCorner ID `X`. Thread lookup is now strictly site-isolated (`f95Id` for F95Zone threads, `lcId` for LewdCorner threads).
 - Fixed `open-game-folder` IPC handler opening the parent directory of the game folder instead of the game directory itself (`selectedVersion.game_path`).

--- a/electron/db/catalogIndex.js
+++ b/electron/db/catalogIndex.js
@@ -918,9 +918,6 @@ const buildIndexWhere = (search = {}, filters = {}) => {
   addTags(filters.tags, { logic: filters.tagLogic === 'OR' ? 'OR' : 'AND' })
   addTags(filters.excludedTags, { exclude: true })
 
-  if (filters.steamMapped === true) {
-    parts.push('(ci.steam_id IS NOT NULL OR ci.has_steam_link = 1)')
-  }
   if (filters.installState === 'installed') parts.push('ci.is_installed = 1')
   else if (filters.installState === 'uninstalled') parts.push('ci.is_installed = 0')
   if (filters.updateAvailable === true) parts.push('ci.is_installed = 1')

--- a/electron/db/versions.js
+++ b/electron/db/versions.js
@@ -1464,10 +1464,6 @@ const getCatalogGamesFromUnion = (appPath, isDev, options = {}) => {
     }
     addTagFilter(filters.tags, { logic: filters.tagLogic === 'OR' ? 'OR' : 'AND' });
     addTagFilter(filters.excludedTags, { exclude: true });
-    if (filters.steamMapped === true) {
-      filterWhereParts.push('(catalog.steam_id IS NOT NULL OR catalog.siteUrl LIKE ?)');
-      filterParams.push('%store.steampowered.com/app/%');
-    }
     if (filters.installState === 'installed') {
       filterWhereParts.push('catalog.is_installed = 1');
     } else if (filters.installState === 'uninstalled') {

--- a/electron/ipc/settings.js
+++ b/electron/ipc/settings.js
@@ -58,7 +58,6 @@ const defaultSavedFilterState = {
   updateAvailable: false,
   favoritesOnly: false,
   wishlistOnly: false,
-  steamMapped: false,
   personalRatingMin: 0,
   personalRatingStatus: 'any',
   personalRatingRatedOnly: false,
@@ -130,7 +129,6 @@ const normalizeSavedFilterState = (filters = {}) => {
   merged.updateAvailable = merged.updateAvailable === true
   merged.favoritesOnly = merged.favoritesOnly === true
   merged.wishlistOnly = merged.wishlistOnly === true
-  merged.steamMapped = merged.steamMapped === true
   const personalRatingMin = Number(merged.personalRatingMin)
   merged.personalRatingMin = Number.isFinite(personalRatingMin)
     ? Math.max(0, Math.min(10, Math.round(personalRatingMin)))

--- a/src/components/search/SearchSidebar.jsx
+++ b/src/components/search/SearchSidebar.jsx
@@ -2,34 +2,10 @@ import { useState, useEffect, useMemo } from 'react'
 import { builtInSavedFilters, getDefaultSortDirectionForSort, normalizeFilterState } from '../../hooks/useFilters.js'
 import SavedFiltersPanel from './SavedFiltersPanel.jsx'
 import SearchScopePicker from './SearchScopePicker.jsx'
+import Collapsible from './ui/Collapsible.jsx'
+import SidebarSection from './sections/SidebarSection.jsx'
+import { quickFiltersList } from './sections/QuickFiltersSection.js'
 import { PLAYSTATE_OPTIONS } from '../../utils/playstates.js'
-
-// Collapsible accordion section — keeps the long filter list scannable so
-// the panel isn't one endless scroll (matches the grouped/accordion layout
-// of the reference filter sidebars). Each section owns its own open state
-// and starts closed unless defaultOpen is set; the most-used sections open
-// by default. An optional badge shows a count/summary next to the title.
-function Collapsible({ title, badge, defaultOpen = false, children }) {
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <div className="border-b border-border">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className="w-full flex items-center justify-between py-3 text-left -webkit-app-region-no-drag"
-      >
-        <span className="font-bold text-sm flex items-center gap-2">
-          {title}
-          {badge != null && badge !== "" && (
-            <span className="text-[11px] font-normal text-muted">{badge}</span>
-          )}
-        </span>
-        <i className={`fas fa-chevron-down text-xs text-muted transition-transform ${open ? "rotate-180" : ""}`}></i>
-      </button>
-      {open && <div className="pb-4">{children}</div>}
-    </div>
-  );
-}
 
 // Sort options shown as the always-visible icon row. Kept intentionally
 // small (Title / Creator / Last Updated / Likes / Rating). "Last Updated"
@@ -346,6 +322,10 @@ const SearchSidebar = ({
 
   const isOverlay = mode !== "inline";
   const isLeft = side === "left";
+
+  // Mode to send in the section params so they can hide filters that don't apply to the current mode
+  // Modify this to have more refined on different modes if needed
+  const currentMode = isCatalogMode ? 'catalog' : 'others';
 
   // The only thing that differs between overlay and inline is the
   // positioning mechanism: overlay is `fixed` and pinned to an edge so it
@@ -884,73 +864,15 @@ const SearchSidebar = ({
               </div>
             </Collapsible>
           )}
-          <Collapsible title="Quick Filters">
-            <div className="space-y-3">
-              {!isCatalogMode && (
-                <div>
-                  <label className="block text-sm mb-1">Library scope</label>
-                  <select
-                    className="w-full p-2 bg-tertiary border border-border rounded text-sm"
-                    value={selectedFilters.installState}
-                    onChange={(e) => {
-                      const installState = e.target.value;
-                      updateFilters({
-                        installState,
-                        includeUninstalled: ['all', 'uninstalled'].includes(installState),
-                      });
-                    }}
-                  >
-                    <option value="installed">Installed titles</option>
-                    <option value="all">Installed and uninstalled</option>
-                    <option value="uninstalled">Uninstalled only</option>
-                  </select>
-                </div>
-              )}
-              {!isCatalogMode && (
-                <label className="flex items-center space-x-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={selectedFilters.updateAvailable || false}
-                    onChange={() => updateFilters({ updateAvailable: !selectedFilters.updateAvailable })}
-                    className="accent-accent -webkit-app-region-no-drag"
-                  />
-                  <span>Show only games with updates available</span>
-                </label>
-              )}
-              {!isCatalogMode && (
-                <label className="flex items-center space-x-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={selectedFilters.favoritesOnly || false}
-                    onChange={() => updateFilters({ favoritesOnly: !selectedFilters.favoritesOnly })}
-                    className="accent-accent -webkit-app-region-no-drag"
-                  />
-                  <span>Favorites only</span>
-                </label>
-              )}
-              {!isCatalogMode && (
-                <label className="flex items-center space-x-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={selectedFilters.multipleInstalledVersions || false}
-                    onChange={() => updateFilters({ multipleInstalledVersions: !selectedFilters.multipleInstalledVersions })}
-                    className="accent-accent -webkit-app-region-no-drag"
-                  />
-                  <span>Show games with multiple installed versions</span>
-                </label>
-              )}
-              <label className="flex items-center space-x-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={selectedFilters.steamMapped || false}
-                  onChange={() => updateFilters({ steamMapped: !selectedFilters.steamMapped })}
-                  className="accent-accent -webkit-app-region-no-drag"
-                />
-                <span>Has Steam mapping</span>
-              </label>
-            </div>
-          </Collapsible>
-
+          
+          {/* Quick Filters Section */}
+          <SidebarSection
+            title="Quick Filters"
+            currentMode={currentMode}
+            filters={quickFiltersList}
+            selectedFilters={selectedFilters}
+            updateFilters={updateFilters}
+          />
         </div>
           </>
         )}

--- a/src/components/search/sections/QuickFiltersSection.js
+++ b/src/components/search/sections/QuickFiltersSection.js
@@ -1,0 +1,38 @@
+const changeLibraryScope = (installState, { updateFilters }) => {
+  updateFilters({
+    installState,
+    includeUninstalled: ['all', 'uninstalled'].includes(installState),
+  })
+}
+
+export const quickFiltersList = [
+  {
+    type: 'dropdown',
+    field: 'installState',
+    label: 'Library scope',
+    options: [
+      { value: 'installed', label: 'Installed titles' },
+      { value: 'all', label: 'Installed and uninstalled' },
+      { value: 'uninstalled', label: 'Uninstalled only' },
+    ],
+    onChange: changeLibraryScope,
+  },
+  {
+    excludeModes: ['catalog'],
+    type: 'checkbox',
+    field: 'updateAvailable',
+    label: 'Show only games with updates available',
+  },
+  {
+    excludeModes: ['catalog'],
+    type: 'checkbox',
+    field: 'favoritesOnly',
+    label: 'Favorites only',
+  },
+  {
+    excludeModes: ['catalog'],
+    type: 'checkbox',
+    field: 'multipleInstalledVersions',
+    label: 'Show games with multiple installed versions',
+  },
+]

--- a/src/components/search/sections/SidebarSection.jsx
+++ b/src/components/search/sections/SidebarSection.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import Collapsible from '../ui/Collapsible.jsx'
+import FilterCheckbox from '../ui/FilterCheckbox.jsx'
+import FilterDropdown from '../ui/FilterDropdown.jsx'
+
+function SidebarSection({ title, currentMode, filters, selectedFilters, updateFilters }) {
+  const visibleFilters = filters.filter((filter) => {
+    if (!filter.excludeModes) return true
+    return !filter.excludeModes.includes(currentMode)
+  })
+
+  if (visibleFilters.length === 0) return null
+
+  // Checkbox filter type
+  const renderFilter = (filter) => {
+    if (filter.type === 'checkbox') {
+      return (
+        <FilterCheckbox
+          checked={selectedFilters[filter.field]}
+          onChange={() => updateFilters({ [filter.field]: !selectedFilters[filter.field] })}
+          label={filter.label}
+        />
+      )
+    }
+
+    // Dropdown filter type
+    if (filter.type === 'dropdown') {
+      return (
+        <FilterDropdown
+          label={filter.label}
+          value={selectedFilters[filter.field]}
+          onChange={(e) => filter.onChange?.(e.target.value, { selectedFilters, updateFilters })}
+        >
+          {filter.options.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </FilterDropdown>
+      )
+    }
+    return filter.content
+  }
+
+  return (
+    <Collapsible title={title}>
+      <div className="space-y-3">
+        {visibleFilters.map((filter, i) => (
+          <React.Fragment key={i}>{renderFilter(filter)}</React.Fragment>
+        ))}
+      </div>
+    </Collapsible>
+  )
+}
+
+export default SidebarSection

--- a/src/components/search/ui/Collapsible.jsx
+++ b/src/components/search/ui/Collapsible.jsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+
+// Collapsible accordion section — keeps the long filter list scannable so
+// the panel isn't one endless scroll (matches the grouped/accordion layout
+// of the reference filter sidebars). Each section owns its own open state
+// and starts closed unless defaultOpen is set; the most-used sections open
+// by default. An optional badge shows a count/summary next to the title.
+export default function Collapsible({ title, badge, defaultOpen = false, children }) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <div className="border-b border-border">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center justify-between py-3 text-left -webkit-app-region-no-drag"
+      >
+        <span className="font-bold text-sm flex items-center gap-2">
+          {title}
+          {badge != null && badge !== "" && (
+            <span className="text-[11px] font-normal text-muted">{badge}</span>
+          )}
+        </span>
+        <i className={`fas fa-chevron-down text-xs text-muted transition-transform ${open ? "rotate-180" : ""}`}></i>
+      </button>
+      {open && <div className="pb-4">{children}</div>}
+    </div>
+  )
+}

--- a/src/components/search/ui/FilterCheckbox.jsx
+++ b/src/components/search/ui/FilterCheckbox.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export default function FilterCheckbox({ checked, onChange, label }) {
+  return (
+    <label className="flex items-center space-x-2 text-sm">
+      <input
+        type="checkbox"
+        checked={Boolean(checked)}
+        onChange={onChange}
+        className="accent-accent -webkit-app-region-no-drag"
+      />
+      <span>{label}</span>
+    </label>
+  )
+}

--- a/src/components/search/ui/FilterDropdown.jsx
+++ b/src/components/search/ui/FilterDropdown.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default function FilterDropdown({ value, onChange, label, children, className = '' }) {
+  return (
+    <div>
+      {label && <label className="block text-sm mb-1">{label}</label>}
+      <select
+        className={`w-full p-2 bg-tertiary border border-border rounded text-sm ${className}`}
+        value={value}
+        onChange={onChange}
+      >
+        {children}
+      </select>
+    </div>
+  )
+}

--- a/src/hooks/useFilters.js
+++ b/src/hooks/useFilters.js
@@ -61,7 +61,6 @@ export const defaultFilters = {
   // atlas_data metadata category (Games/Comics/etc.).
   collectionIds: [],
   wishlistOnly: false,
-  steamMapped: false,
   personalRatingMin: 0,
   personalRatingStatus: 'any',
   personalRatingRatedOnly: false,
@@ -240,7 +239,6 @@ export const normalizeFilterState = (filters = {}) => {
   merged.updateAvailable = merged.updateAvailable === true
   merged.favoritesOnly = merged.favoritesOnly === true
   merged.wishlistOnly = merged.wishlistOnly === true
-  merged.steamMapped = merged.steamMapped === true
   const personalRatingMin = Number(merged.personalRatingMin)
   merged.personalRatingMin = Number.isFinite(personalRatingMin)
     ? Math.max(0, Math.min(10, Math.round(personalRatingMin)))
@@ -710,10 +708,6 @@ const getLewdCornerIdValues = (game = {}) => [
   ...getExternalValues(game, ['lc_id', 'lcId', 'lewdcornerId', 'lewdCornerId', 'lewdcorner_id']),
 ]
 
-const hasSteamMapping = (game = {}) =>
-  getSteamIdValues(game).some((value) => /^\d+$/.test(cleanIdText(value))) ||
-  getUrlValues(game).some((url) => urlMatchesSource(url, 'steam'))
-
 const getUrlValues = (game = {}) => {
   const externalIds = getExternalIds(game)
   return [
@@ -1027,10 +1021,6 @@ export const filterGamesWithState = (games, filters = {}, options = {}) => {
       const rating = Math.max(f95 ?? 0, lc ?? 0)
       return rating > 0 && rating >= activeFilters.communityRatingMin
     })
-  }
-
-  if (activeFilters.steamMapped) {
-    result = result.filter(hasSteamMapping)
   }
 
   if (activeFilters.installState === 'installed') {

--- a/tests/component-render-smoke.test.jsx
+++ b/tests/component-render-smoke.test.jsx
@@ -23,6 +23,8 @@ import CollectionModal from '../src/components/collections/CollectionModal.jsx'
 import GameTree from '../src/components/library/GameTree.jsx'
 import Settings from '../src/components/settings/Settings.jsx'
 import ExtensionSettings from '../src/components/settings/ExtensionSettings.jsx'
+import SidebarSection from '../src/components/search/sections/SidebarSection.jsx'
+import { quickFiltersList } from '../src/components/search/sections/QuickFiltersSection.js'
 
 // Components that call useKnownTags() fetch on mount and set state when the
 // promise resolves. Rendering them outside act() produces a "not wrapped in
@@ -203,4 +205,43 @@ test('ExtensionSettings mounts and shows extension info', async () => {
   await renderSettled(<ExtensionSettings />)
   expect(screen.getByText('Browser Extension')).toBeTruthy()
   expect(screen.getByText('Atlas RPC Local Server')).toBeTruthy()
+})
+
+test('SidebarSection has quick filters in library mode', async () => {
+  await renderSettled(
+    <SidebarSection
+      title="Quick Filters"
+      currentMode="library"
+      filters={quickFiltersList}
+      selectedFilters={{ installState: 'installed' }}
+      updateFilters={() => {}}
+    />,
+  )
+  expect(screen.getByText('Quick Filters')).toBeTruthy()
+})
+
+test('SidebarSection has quick filters in catalog mode', async () => {
+  await renderSettled(
+    <SidebarSection
+      title="Quick Filters"
+      currentMode="catalog"
+      filters={quickFiltersList}
+      selectedFilters={{ installState: 'installed' }}
+      updateFilters={() => {}}
+    />,
+  )
+  expect(screen.getByText('Quick Filters')).toBeTruthy()
+})
+
+test('SidebarSection returns null when no filters are visible', async () => {
+  const { container } = render(
+    <SidebarSection
+      title="Empty"
+      currentMode="catalog"
+      filters={[]}
+      selectedFilters={{}}
+      updateFilters={() => {}}
+    />,
+  )
+  expect(container.innerHTML).toBe('')
 })


### PR DESCRIPTION
## What this changes

- Remove "has steam mapping" quick filter
- Initial refactor for SearchSideBar for common UI and template - started with QuickFilters section

## Why

- Obsolete feature and remove per request
https://github.com/towerwatchman/Atlas/issues/349

## How it was tested

- [x] Verify changes in GUI
- [x] Added tests that cover this change  
- [x] For a fix: the regression test fails against the unfixed code
- [x] `npm run check` passes locally
- [x] New functions and IPC handlers have comments explaining *why*
- [x] `CHANGELOG.md` updated
- [x] This PR targets `nightly`, not `main`

```
BEFORE & AFTER:

npm run check
 ...
 ✖ 67 problems (0 errors, 67 warnings)
  0 errors and 1 warning potentially fixable with the `--fix` option.
 ...
 Test Files  1 failed | 79 passed (80)
 Tests  2 failed | 989 passed | 7 skipped (998)
```
## AI assistance

- [x] No AI was used on this change
- [ ] AI was used on this change - Test generation only

NOTE: Originally no AI but the PR policy complaint about no test on the refactor, so I added a smoke test under tests/component-render-smoke.test.jsx. Change verified via GUI mainly.

## Anything the reviewer should know
- Trying to sort of understanding the codebase and the flat files were killing me. I figured small refactor to understand code would be best. Let me know if it is an issue in the code style.
- Can you review and see if my steamMap remove affect any of other features you know of like steam id or url search? Seem to work for id in my library but idk if this is used anywhere in your other attempt to do it via browse. Search "steamMapped" for steamMapped filter related removal - I remove the UI as well as related code that use it since it is obsolete. The rest are refactoring.