### PR TITLE
Fix/remove steam mapping filter

### DIFF
--- a/electron/db/updateProgress.js
+++ b/electron/db/updateProgress.js
@@ -1,0 +1,116 @@
+'use strict'
+
+// ── Database update progress ─────────────────────────────────────────────────
+//
+// Turns "which package, which phase, how many bytes so far" into the single
+// number the progress bar draws, plus the line of text above it.
+//
+// The bar used to be handed `processed` — a count of packages that had finished
+// EVERYTHING. So it moved once per package and sat frozen in between, and the
+// longest freeze was the one nobody could explain: the network transfer, where
+// the text said "Downloading Database Update 3/25" and nothing moved until the
+// whole package had landed. On a slow link that is indistinguishable from a
+// hang.
+//
+// Progress is now fractional within a package. The download owns the first half
+// of each package's share and advances with the bytes; the three metadata insert
+// phases split the rest.
+//
+// ── Why the download gets half ───────────────────────────────────────────────
+//
+// Not measured, chosen. The real split varies wildly — a fat snapshot package on
+// a fast connection is nearly all insert time, the same package abroad is nearly
+// all transfer. Half is the honest compromise: neither phase can stall the bar
+// for more than half a package's width, which is the property that matters. It
+// is a progress bar, not a stopwatch.
+
+const PHASE_STARTS = {
+  download: 0,
+  atlas: 0.5,
+  f95: 0.67,
+  lewdcorner: 0.84,
+  // Reconciliation only runs for snapshot packages, so it shares the tail with
+  // lewdcorner rather than claiming a slice every package would have to pay for.
+  reconcile: 0.92,
+  done: 1,
+}
+
+// The download's share of one package. The remainder is the insert phases.
+const DOWNLOAD_SHARE = PHASE_STARTS.atlas
+
+/**
+ * Where the bar should sit, in units of packages.
+ *
+ * @param {number} processed     Packages fully finished before this one.
+ * @param {string} phase         A key of PHASE_STARTS.
+ * @param {number} byteFraction  0..1, only meaningful during 'download'.
+ * @returns {number}             processed <= value < processed + 1
+ */
+function packageProgress(processed = 0, phase = 'download', byteFraction = 0) {
+  const base = Number.isFinite(processed) && processed > 0 ? processed : 0
+  const start = PHASE_STARTS[phase] ?? 0
+
+  if (phase !== 'download') return base + start
+
+  // Guard the fraction rather than trusting it: axios reports `total` as
+  // undefined when the server omits Content-Length, and loaded/undefined is
+  // NaN. A NaN here silently blanks the bar (width: NaN%), which is how a
+  // missing header would have turned into an invisible progress bar.
+  const fraction = Number(byteFraction)
+  if (!Number.isFinite(fraction) || fraction <= 0) return base
+  return base + Math.min(fraction, 1) * DOWNLOAD_SHARE
+}
+
+/**
+ * Bytes to a short human string. Deliberately coarse — this sits in a 300px
+ * label next to a counter, and a second decimal place is noise at that size.
+ */
+function formatUpdateBytes(bytes) {
+  const value = Number(bytes)
+  if (!Number.isFinite(value) || value <= 0) return null
+  const mb = value / (1024 * 1024)
+  if (mb >= 1) return `${mb.toFixed(1)} MB`
+  return `${Math.max(1, Math.round(value / 1024))} KB`
+}
+
+/**
+ * The line above the bar during a transfer.
+ *
+ * Falls back to the bare "Downloading Database Update 3/25" when the size is
+ * unknown, which happens whenever the server omits Content-Length. Showing
+ * "4.2 MB of 0 MB" would be worse than showing nothing.
+ */
+function downloadText(position, total, loaded = 0, size = 0) {
+  const head = `Downloading Database Update ${position}/${total}`
+  const totalText = formatUpdateBytes(size)
+  if (!totalText) return head
+  // The loaded side is allowed to read 0 — a transfer that has not started is a
+  // true statement, and it makes the first tick visible rather than jumping.
+  const loadedMb = Math.max(0, Number(loaded) || 0) / (1024 * 1024)
+  return `${head} (${loadedMb.toFixed(1)} / ${totalText})`
+}
+
+/**
+ * Which package the counter under the bar should name.
+ *
+ * Progress is fractional now, so the raw value would render as "Update 3.4/25".
+ * Floor-plus-one names the package being WORKED ON rather than the count
+ * completed — which also fixes the old bar opening on "Update 0/25" before
+ * anything had a chance to finish.
+ */
+function currentPackageNumber(progress, total) {
+  const value = Number(progress)
+  const count = Number(total)
+  if (!Number.isFinite(value) || !Number.isFinite(count) || count <= 0) return 0
+  if (value >= count) return count
+  return Math.min(Math.floor(Math.max(value, 0)) + 1, count)
+}
+
+module.exports = {
+  PHASE_STARTS,
+  DOWNLOAD_SHARE,
+  packageProgress,
+  formatUpdateBytes,
+  downloadText,
+  currentPackageNumber,
+}

--- a/electron/db/updates.js
+++ b/electron/db/updates.js
@@ -280,6 +280,7 @@ const checkDbUpdates = async (updatesDir, mainWindow) => {
   const lz4 = require("lz4js");
   const http = require("http");
   const https = require("https");
+  const { packageProgress, downloadText } = require("./updateProgress");
 
   // Atlas ids touched by this run, so the browse index can be brought up to
   // date incrementally instead of rebuilt from scratch after every sync.
@@ -347,13 +348,58 @@ const checkDbUpdates = async (updatesDir, mainWindow) => {
     // Insertion stays strictly sequential to preserve ordering guarantees
     // (f95_latest_order, snapshot pruning, and the updates ledger).
     const PREFETCH = 4;
-    const downloadPackage = async (update) => {
+
+    // Live byte counts per package, so the bar can move DURING a transfer
+    // instead of freezing until the whole package lands.
+    //
+    // Indexed rather than kept as a single "current" pair because up to
+    // PREFETCH downloads are in flight at once: package 5 reporting bytes while
+    // the loop is still waiting on package 3 must not overwrite what the bar is
+    // showing. Only the awaited index is ever emitted; the rest is bookkeeping
+    // for when its turn comes.
+    const transfers = new Array(ordered.length);
+    // Which package the loop is actually waiting on. Downloads that finished
+    // ahead of the loop report into `transfers` and are read back when reached.
+    let awaiting = 0;
+
+    const sendDownloadProgress = (i) => {
+      const seen = transfers[i] || { loaded: 0, size: 0 };
+      mainWindow.webContents.send("db-update-progress", {
+        text: downloadText(i + 1, total, seen.loaded, seen.size),
+        progress: packageProgress(i, "download", seen.size > 0 ? seen.loaded / seen.size : 0),
+        total,
+      });
+    };
+
+    const downloadPackage = async (update, index) => {
       try {
         const downloadUrl = `https://atlas-gamesdb.com/packages/${update.name}`;
         const outputPath = path.join(updatesDir, update.name);
-        const res = await client.get(downloadUrl, { responseType: "arraybuffer" });
+        const res = await client.get(downloadUrl, {
+          responseType: "arraybuffer",
+          // `total` is undefined when the server omits Content-Length, which is
+          // why the size is carried separately and the text falls back to the
+          // bare counter rather than printing "of 0 MB".
+          onDownloadProgress: (event) => {
+            transfers[index] = {
+              loaded: Number(event?.loaded) || 0,
+              size: Number(event?.total) || 0,
+            };
+            // Only the package being waited on drives the bar. A prefetched
+            // download three slots ahead reporting here would make the bar jump
+            // forward and then back when the loop caught up.
+            if (index === awaiting) sendDownloadProgress(index);
+          },
+        });
         const buffer = Buffer.from(res.data);
         fs.writeFileSync(outputPath, buffer);
+        // Settle the record even when no progress event ever fired (a small
+        // package can arrive in one chunk), so the completed transfer reads as
+        // complete rather than as never started.
+        transfers[index] = {
+          loaded: buffer.length,
+          size: transfers[index]?.size || buffer.length,
+        };
         return { ok: true, buffer };
       } catch (error) {
         // Resolve (never reject) so a prefetched failure can't trigger an
@@ -365,7 +411,7 @@ const checkDbUpdates = async (updatesDir, mainWindow) => {
 
     const downloads = new Array(ordered.length);
     const startDownload = (i) => {
-      if (i < ordered.length && !downloads[i]) downloads[i] = downloadPackage(ordered[i]);
+      if (i < ordered.length && !downloads[i]) downloads[i] = downloadPackage(ordered[i], i);
     };
     for (let i = 0; i < Math.min(PREFETCH, ordered.length); i += 1) startDownload(i);
 
@@ -432,7 +478,7 @@ const checkDbUpdates = async (updatesDir, mainWindow) => {
       if (isSnapshot) {
         mainWindow.webContents.send("db-update-progress", {
           text: `Reconciling removed games ${processed + 1}/${total}`,
-          progress: processed,
+          progress: packageProgress(processed, "reconcile"),
           total,
         });
         try {

--- a/electron/downloads/hosts/mega.js
+++ b/electron/downloads/hosts/mega.js
@@ -48,6 +48,33 @@ const ERROR_CODES = {
   "-27": { kind: "auth", message: "That two-factor code was not accepted." },
 };
 
+// MEGA reports the SAME failures in two different shapes, and only one of them
+// was ever read.
+//
+//   [-9]          -> unwrapped to the bare number -9 by sendRequest
+//   [{"e": -9}]   -> an OBJECT carrying the code, which is what a deleted or
+//                    taken-down file actually comes back as
+//
+// The second shape fell through to the "MEGA's response did not include a
+// download URL" fallback: untrue, and classified transient, so Atlas retried a
+// permanently dead link forever instead of reporting it gone.
+//
+// Both shapes go through one place now. Returns null when the entry carries no
+// error, so a caller can treat null as "keep going".
+function entryError(entry) {
+  if (typeof entry === "number") return { ...errorFor(entry), code: entry, shape: "bare" };
+  if (!entry || typeof entry !== "object") return null;
+  // Deliberately not `Number(entry.e)` on a missing key: Number(undefined) is
+  // NaN, but Number(null) and Number("") are both 0, and 0 is MEGA's SUCCESS
+  // code — treating a null `e` as error 0 would invent a failure.
+  if (!Object.prototype.hasOwnProperty.call(entry, "e")) return null;
+  const code = Number(entry.e);
+  if (!Number.isFinite(code)) return null;
+  // A literal 0 is success, not an error to report.
+  if (code === 0) return null;
+  return { ...errorFor(code), code, shape: "entry.e" };
+}
+
 function errorFor(code) {
   return ERROR_CODES[String(code)]
     || { kind: "transient", message: `MEGA returned error ${code}.` };
@@ -381,15 +408,23 @@ async function probe(url, credentials = {}) {
     };
   }
 
-  // Either `-2` or `[-2]`; a success is `[{ … }]`.
+  // A bare `-2`, a wrapped `[-2]`, or an object carrying `e`. Success is
+  // `[{ g: ... }]`. See entryError() for why both error shapes exist.
   const entry = result.entry;
-  if (typeof entry === "number") {
-    const mapped = errorFor(entry);
+  const failure = entryError(entry);
+  if (failure) {
     return {
-      ok: false, kind: mapped.kind, error: mapped.message,
-      diagnostic: { megaError: entry, fileId: link.id, authenticated: Boolean(session) },
+      ok: false, kind: failure.kind, error: failure.message,
+      diagnostic: {
+        megaError: failure.code, shape: failure.shape,
+        fileId: link.id, authenticated: Boolean(session),
+      },
     };
   }
+
+  // Genuinely unrecognised now: an object with neither a download URL nor an
+  // error code. Kept transient because an unparseable response really might be
+  // a blip, unlike the coded failures above.
   if (!entry || typeof entry !== "object" || !entry.g) {
     return {
       ok: false, kind: "transient",
@@ -623,4 +658,6 @@ module.exports = {
   // Exported for tests
   fileIdFrom,
   ERROR_CODES,
+  // Exported for tests
+  entryError,
 };

--- a/electron/ipc/importer.js
+++ b/electron/ipc/importer.js
@@ -2007,7 +2007,7 @@ ipcMain.handle("import-catalog-entry", async (event, payload = {}) => {
       await fsp.mkdir(path.dirname(targetBase), { recursive: true });
       await fsp.cp(sourcePath, targetBase, { recursive: true });
       gamePath = targetBase;
-      const execs = findExecutables(gamePath, extensions);
+      const execs = await findExecutables(gamePath, extensions);
       relativeExec = execs[0] || "";
       execPath = relativeExec ? path.join(gamePath, relativeExec) : "";
     } else if (sourceIsArchive) {
@@ -2048,7 +2048,7 @@ ipcMain.handle("import-catalog-entry", async (event, payload = {}) => {
         await fsp.rmdir(subPath).catch(() => {});
       }
 
-      const execs = findExecutables(gamePath, extensions);
+      const execs = await findExecutables(gamePath, extensions);
       relativeExec = execs[0] || "";
       execPath = relativeExec ? path.join(gamePath, relativeExec) : "";
     } else if (stat.isFile()) {
@@ -2273,7 +2273,7 @@ ipcMain.handle("import-local-game-version", async (event, payload = {}) => {
       await fsp.mkdir(path.dirname(targetBase), { recursive: true });
       await fsp.cp(sourcePath, targetBase, { recursive: true });
       gamePath = targetBase;
-      const execs = findExecutables(gamePath, extensions);
+      const execs = await findExecutables(gamePath, extensions);
       console.log("[LocalImport] Folder executable scan", { gamePath, execCount: execs.length, execs });
       relativeExec = execs[0] || "";
       execPath = relativeExec ? path.join(gamePath, relativeExec) : "";
@@ -2314,7 +2314,7 @@ ipcMain.handle("import-local-game-version", async (event, payload = {}) => {
         await fsp.rmdir(subPath).catch(() => {});
         console.log("[LocalImport] Flattened single archive root", { gamePath, subPath });
       }
-      const execs = findExecutables(gamePath, extensions);
+      const execs = await findExecutables(gamePath, extensions);
       console.log("[LocalImport] Archive executable scan", { gamePath, execCount: execs.length, execs });
       relativeExec = execs[0] || "";
       execPath = relativeExec ? path.join(gamePath, relativeExec) : "";
@@ -3482,7 +3482,7 @@ ipcMain.handle("import-games", async (event, params) => {
 
         // ── Find executables after extraction ────────────────────────────────
         const { findExecutables } = require("../scanners/executableScanner");
-        let execs = findExecutables(extractPath, gameExt);
+        let execs = await findExecutables(extractPath, gameExt);
 
         // Clean up common unwanted root-level folders
         const foldersToRemove = ["__MACOSX", "__LINUX"];
@@ -3529,7 +3529,7 @@ ipcMain.handle("import-games", async (event, params) => {
           } catch {}
 
           // Re-scan executables after flattening
-          execs = findExecutables(extractPath, gameExt);
+          execs = await findExecutables(extractPath, gameExt);
         }
 
         // ── Executable selection ─────────────────────────────────────────────
@@ -4821,7 +4821,7 @@ ipcMain.handle("downloads-install", async (event, { id, version, onComplete, kee
     await downloadManager.setItemState(id, "importing");
 
     const extensions = getConfiguredGameExtensions(currentConfig);
-    const relativeExec = findExecutables(gamePath, extensions)[0] || "";
+    const relativeExec = (await findExecutables(gamePath, extensions))[0] || "";
     const execPath = relativeExec ? path.join(gamePath, relativeExec) : "";
     const folderSize = await calculatePathSizeSafe(gamePath);
 

--- a/electron/scanners/executableScanner.js
+++ b/electron/scanners/executableScanner.js
@@ -1,67 +1,113 @@
-const fs = require("fs");
+const fsp = require("fs").promises;
 const path = require("path");
 const { isImportBlacklisted } = require("./importBlacklist");
 
-function findExecutables(dir, extensions) {
-  const execs = [];
-  // Each stack entry is { path, isRoot } — only descend into subdirs if no
-  // executables were found directly in the current directory (same logic as old
-  // scanner, but correctly applied: collect files and dirs separately per level).
-  const stack = [dir];
+// ── Executable scanner ───────────────────────────────────────────────────────
+//
+// Finds the launcher inside a game folder. Async and breadth-first, and it stops
+// the moment any directory yields a match.
+//
+// It used to be `fs.readdirSync` in a loop, on the main process. That is fine
+// right up until it isn't: the walk only descends into a directory when the one
+// above it had no matches, so a RenPy game (launcher under `game/`), an HTML
+// game with no .exe at all, or any archive whose contents miss the configured
+// extension list sends it through the ENTIRE extracted tree with the event loop
+// blocked the whole way. Nothing paints, no IPC resolves, every window freezes.
+// Installing a 40k-file game hung the client outright.
+//
+// This is the same fix electron/db/versions.js already made for the startup
+// exec-path repair (see findLaunchablesInFolderAsync there) — awaiting each
+// readdir hands control back between directories, so a slow walk is slow instead
+// of fatal. The install path never got the same treatment; now it has.
+//
+// ── Why breadth-first, and why it stops ──────────────────────────────────────
+//
+// The old walk used a LIFO stack, so it went depth-first down whichever branch
+// happened to be last, and "don't descend" only applied to the directory that
+// matched — sibling branches already on the stack were still walked to the
+// bottom. It also collected across the whole tree and every caller then took
+// [0], so most of that work was thrown away.
+//
+// Breadth-first reaches the shallowest executable first, which is the one that
+// is almost always right: the launcher sits at the game root, and anything
+// deeper is a bundled runtime (`lib/python.exe`, `www/nw.exe`). Returning as
+// soon as a directory produces matches means a normal game costs ONE readdir,
+// and the pathological case costs a level of the tree rather than all of it.
+//
+// The trade is real and worth stating: a launcher buried below a directory that
+// happens to contain some other matching file will no longer be found. Every
+// caller takes [0] and the shallowest match is what [0] meant in practice, so
+// this changes which single path is picked only in trees where the old answer
+// was already arbitrary.
 
-  console.log(`Scanning for executables in: ${dir}`);
-  console.log(`Allowed extensions: ${extensions.join(", ")}`);
+/**
+ * @param {string} dir              Folder to search.
+ * @param {string[]} extensions     Allowed extensions, without dots.
+ * @returns {Promise<string[]>}     Paths relative to `dir`, shallowest first.
+ *                                  Empty when nothing matches.
+ */
+async function findExecutables(dir, extensions) {
+  if (!dir) return [];
 
-  while (stack.length) {
-    const current = stack.pop();
+  const allowed = new Set(
+    (Array.isArray(extensions) ? extensions : [])
+      .map((value) => String(value || "").trim().toLowerCase().replace(/^\./, ""))
+      .filter(Boolean),
+  );
+  if (allowed.size === 0) return [];
 
-    let items;
-    try {
-      items = fs.readdirSync(current, { withFileTypes: true });
-    } catch (err) {
-      console.warn(`Cannot read directory ${current}: ${err.message}`);
-      continue;
-    }
+  // FIFO. The old stack was LIFO, which is what made the walk depth-first.
+  let level = [dir];
 
-    // Separate files and subdirs in one pass
-    const subdirs = [];
-    let foundInThisDir = false;
+  while (level.length > 0) {
+    const nextLevel = [];
 
-    for (const item of items) {
-      const fullPath = path.join(current, item.name);
-
-      if (item.isDirectory()) {
-        subdirs.push(fullPath);
+    for (const current of level) {
+      let items;
+      try {
+        items = await fsp.readdir(current, { withFileTypes: true });
+      } catch (err) {
+        // An unreadable directory is skipped, not fatal. A permission-denied
+        // subfolder should not cost the caller its executable.
+        console.warn(`Cannot read directory ${current}: ${err.message}`);
         continue;
       }
 
-      if (!item.isFile()) continue;
+      const matches = [];
+      for (const item of items) {
+        const fullPath = path.join(current, item.name);
 
-      const ext = path.extname(item.name).toLowerCase().slice(1);
-      const nameLower = item.name.toLowerCase();
+        if (item.isDirectory()) {
+          nextLevel.push(fullPath);
+          continue;
+        }
+        if (!item.isFile()) continue;
 
-      if (!extensions.includes(ext)) continue;
-      if (isImportBlacklisted(item.name) || nameLower.includes("-32")) continue;
+        const ext = path.extname(item.name).toLowerCase().slice(1);
+        if (!allowed.has(ext)) continue;
+        // `-32` skips the 32-bit twin that ships beside the real launcher.
+        if (isImportBlacklisted(item.name) || item.name.toLowerCase().includes("-32")) continue;
 
-      // Valid executable found
-      const relative = path.relative(dir, fullPath);
-      execs.push(relative);
-      console.log(`Found executable: ${relative}`);
-      foundInThisDir = true;
-    }
+        matches.push(path.relative(dir, fullPath));
+      }
 
-    // Only descend into subdirectories if this directory had no matches.
-    // This matches the original fast behaviour: game root contains the exe,
-    // so we don't need to recurse into runtime subdirs (www, game, lib, etc.)
-    if (!foundInThisDir) {
-      for (const subdir of subdirs) {
-        stack.push(subdir);
+      if (matches.length > 0) {
+        // Done — the whole walk, not just this branch. Sorted so a folder with
+        // several candidates returns the same [0] every run rather than
+        // whatever order the filesystem reported.
+        matches.sort((a, b) => a.localeCompare(b));
+        console.log(`Executable scan matched in ${current}: ${matches.length} candidate(s)`);
+        return matches;
       }
     }
+
+    level = nextLevel;
   }
 
-  console.log(`Total executables found: ${execs.length}`);
-  return execs;
+  // Worth logging: the caller is about to store a blank exec path, and the
+  // configured extension list is the usual reason.
+  console.log(`Executable scan found nothing under ${dir}`);
+  return [];
 }
 
 module.exports = { findExecutables };

--- a/electron/scanners/f95scanner.js
+++ b/electron/scanners/f95scanner.js
@@ -443,7 +443,7 @@ async function startScan(params, window, cancelToken = {}) {
             ? format.split("/").map((p) => p.trim()).filter(Boolean).length
             : 0;
         if (schemeSegmentCount === 1 && target !== folder) {
-          const nestedLaunchables = findExecutables(target, extensions);
+          const nestedLaunchables = await findExecutables(target, extensions);
           if (nestedLaunchables.length > 0) {
             const res = await findGame(
               target,
@@ -546,7 +546,7 @@ async function startScan(params, window, cancelToken = {}) {
           // root-level search: recursing everywhere would promote every
           // ancestor directory, creator folders included, into a game.
           const subdirLaunchables = candidate.ownsRuntimeChild
-            ? findExecutables(subdir, extensions)
+            ? await findExecutables(subdir, extensions)
             : getRootFiles(subdir, extensions).map((f) => path.basename(f));
           if (subdirLaunchables.length > 0) {
             console.log(`Scanning version directory: ${subdir}`);

--- a/electron/scanners/gogscanner.js
+++ b/electron/scanners/gogscanner.js
@@ -704,7 +704,7 @@ async function startGogScan(db, params, event) {
         }
         if (!execPath) {
           try {
-            const found = findExecutables(installDir, ["exe"]);
+            const found = await findExecutables(installDir, ["exe"]);
             if (found && found.length > 0) {
               relativeExec = found[0];
               execPath = path.join(installDir, found[0]);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2532,7 +2532,15 @@ const App = () => {
                 <div className="h-full bg-progressForeground" style={{ width: `${(dbUpdateStatus.progress / (dbUpdateStatus.total || 1)) * 100}%` }}></div>
               </div>
               <span className="absolute inset-0 flex items-center justify-center text-[10px] text-text">
-                Update {formatProgressNumber(dbUpdateStatus.progress)}/{formatProgressNumber(dbUpdateStatus.total)}
+                {/* Floor-plus-one, not the raw value. Progress is fractional
+                    within a package now so the bar can move during a download
+                    (see electron/db/updateProgress.js), and formatProgressNumber
+                    would render that as "Update 3.4/25". This names the package
+                    being worked on, which also fixes the old label opening on
+                    "Update 0/25" before anything had finished. */}
+                Update {formatProgressNumber(
+                  Math.min(Math.floor(Math.max(dbUpdateStatus.progress, 0)) + 1, dbUpdateStatus.total),
+                )}/{formatProgressNumber(dbUpdateStatus.total)}
               </span>
             </div>
           </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2804,7 +2804,26 @@ const App = () => {
           updateAllOpen || aboutOpen || showWelcomeTour || showWelcome || nsfwPromptOpen ||
           Boolean(collectionModal) || Boolean(pendingCollectionDelete) || Boolean(bulkTagTarget)
         }
-        onInstalled={(result) => { if (result?.success) fetchGames() }}
+        onInstalled={(result) => {
+          // skipPathValidation is NOT optional here. Without it, getGames maps
+          // every version of every game through mapVersionRow, which runs a
+          // synchronous fs.existsSync on both game_path and exec_path — two
+          // blocking stats per version, across the whole library, on the main
+          // process. On an SSD that is invisible. On a 6k-game library on a
+          // mechanical drive it is thousands of seeks and the app stops
+          // responding, which is what a user reported as "all version folders
+          // are being scanned after an install".
+          //
+          // Validation is meant to be the deliberate, throttled pass in
+          // validate-library-paths (one record at a time, yielding every 25,
+          // gated behind Library.validatePathsOnStartup). An install is not a
+          // request to re-verify the entire library.
+          //
+          // The versions of the game just installed are still verified: the
+          // install handler broadcasts game-updated with a full getGame()
+          // record, and that one DOES stat its own versions.
+          if (result?.success) fetchGames(includeUninstalledRef.current, { skipPathValidation: true })
+        }}
       />
 
     </div>

--- a/src/components/search/SearchSidebar.jsx
+++ b/src/components/search/SearchSidebar.jsx
@@ -939,15 +939,6 @@ const SearchSidebar = ({
                   <span>Show games with multiple installed versions</span>
                 </label>
               )}
-              <label className="flex items-center space-x-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={selectedFilters.steamMapped || false}
-                  onChange={() => updateFilters({ steamMapped: !selectedFilters.steamMapped })}
-                  className="accent-accent -webkit-app-region-no-drag"
-                />
-                <span>Has Steam mapping</span>
-              </label>
             </div>
           </Collapsible>
 

--- a/tests/db-update-progress.test.js
+++ b/tests/db-update-progress.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+
+const {
+  PHASE_STARTS,
+  packageProgress,
+  formatUpdateBytes,
+  downloadText,
+  currentPackageNumber,
+} = require('../electron/db/updateProgress')
+
+// ── Database update progress ─────────────────────────────────────────────────
+//
+// The bar used to be handed `processed` — a count of packages that had finished
+// EVERYTHING — so it moved once per package and froze in between. The longest
+// freeze was the network transfer, where the text said "Downloading Database
+// Update 3/25" and nothing moved until the whole package landed. On a slow link
+// that is indistinguishable from a hang, which is the bug these cover.
+
+describe('packageProgress', () => {
+  it('advances with the bytes during a download instead of sitting still', () => {
+    // The regression. All four of these used to be exactly 2.
+    expect(packageProgress(2, 'download', 0)).toBe(2)
+    expect(packageProgress(2, 'download', 0.5)).toBeCloseTo(2.25)
+    expect(packageProgress(2, 'download', 1)).toBeCloseTo(2.5)
+  })
+
+  it('keeps each phase inside its own package', () => {
+    // A phase that spilled past processed + 1 would show the bar overtaking a
+    // package that has not been inserted yet.
+    for (const phase of Object.keys(PHASE_STARTS)) {
+      const value = packageProgress(3, phase, 1)
+      expect(value).toBeGreaterThanOrEqual(3)
+      expect(value).toBeLessThanOrEqual(4)
+    }
+  })
+
+  it('moves through the insert phases rather than freezing until the package ends', () => {
+    // The three "Processing…" sends all reported the same number, so the bar was
+    // frozen through the whole insert half too.
+    const atlas = packageProgress(1, 'atlas')
+    const f95 = packageProgress(1, 'f95')
+    const lewd = packageProgress(1, 'lewdcorner')
+    expect(f95).toBeGreaterThan(atlas)
+    expect(lewd).toBeGreaterThan(f95)
+  })
+
+  it('never goes backwards from a full download into the first insert phase', () => {
+    expect(packageProgress(1, 'atlas')).toBeGreaterThanOrEqual(packageProgress(1, 'download', 1))
+  })
+
+  it('treats a missing Content-Length as no fraction rather than blanking the bar', () => {
+    // axios reports `total` as undefined when the server omits the header, and
+    // loaded/undefined is NaN. A NaN reaches the DOM as width: NaN%, which is an
+    // invisible progress bar — worse than a stationary one.
+    expect(packageProgress(2, 'download', NaN)).toBe(2)
+    expect(packageProgress(2, 'download', undefined)).toBe(2)
+    expect(packageProgress(2, 'download', Infinity)).toBe(2)
+  })
+
+  it('clamps a fraction that overshoots', () => {
+    // Content-Length can under-report against a re-encoded body.
+    expect(packageProgress(2, 'download', 1.4)).toBeCloseTo(2.5)
+  })
+
+  it('falls back to the start of the package for an unknown phase', () => {
+    expect(packageProgress(4, 'not-a-phase')).toBe(4)
+  })
+})
+
+describe('downloadText', () => {
+  it('shows how much of the package has arrived', () => {
+    expect(downloadText(3, 25, 4.2 * 1024 * 1024, 7.1 * 1024 * 1024))
+      .toBe('Downloading Database Update 3/25 (4.2 / 7.1 MB)')
+  })
+
+  it('drops the size entirely when the server did not send one', () => {
+    // "4.2 MB of 0 MB" would be worse than saying nothing.
+    expect(downloadText(3, 25, 0, 0)).toBe('Downloading Database Update 3/25')
+    expect(downloadText(3, 25, 1024, undefined)).toBe('Downloading Database Update 3/25')
+  })
+
+  it('reads 0.0 rather than hiding a transfer that has not started', () => {
+    expect(downloadText(1, 5, 0, 2 * 1024 * 1024)).toContain('(0.0 / 2.0 MB)')
+  })
+})
+
+describe('formatUpdateBytes', () => {
+  it('uses MB above a megabyte and KB below it', () => {
+    expect(formatUpdateBytes(5 * 1024 * 1024)).toBe('5.0 MB')
+    expect(formatUpdateBytes(300 * 1024)).toBe('300 KB')
+  })
+
+  it('reports nothing for a size it cannot use', () => {
+    expect(formatUpdateBytes(0)).toBeNull()
+    expect(formatUpdateBytes(undefined)).toBeNull()
+    expect(formatUpdateBytes(-5)).toBeNull()
+  })
+})
+
+describe('currentPackageNumber', () => {
+  it('names the package being worked on, not the count completed', () => {
+    // The old label opened on "Update 0/25" because it printed completed
+    // packages before anything had finished.
+    expect(currentPackageNumber(0, 25)).toBe(1)
+    expect(currentPackageNumber(3.4, 25)).toBe(4)
+  })
+
+  it('does not run past the total on the last package', () => {
+    expect(currentPackageNumber(24.9, 25)).toBe(25)
+    expect(currentPackageNumber(25, 25)).toBe(25)
+    expect(currentPackageNumber(99, 25)).toBe(25)
+  })
+
+  it('reports zero when there is nothing to count', () => {
+    expect(currentPackageNumber(0, 0)).toBe(0)
+    expect(currentPackageNumber(NaN, 25)).toBe(0)
+  })
+})

--- a/tests/executable-scanner.test.js
+++ b/tests/executable-scanner.test.js
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const { findExecutables } = require('../electron/scanners/executableScanner')
+
+// ── Executable scanner ───────────────────────────────────────────────────────
+//
+// This walk runs on the MAIN PROCESS during an install. When it was synchronous
+// it froze every window in the app for as long as it took, and it took longest
+// in exactly the case it handled worst: a game with no executable at the root,
+// where it walked the entire extracted tree with the event loop blocked. A 40k
+// file game hung the client outright.
+//
+// So the load-bearing assertion here is not "it finds the exe" - it is that the
+// event loop keeps turning while it works, and that it stops as soon as it has
+// an answer.
+
+let root
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'atlas-exec-scan-'))
+})
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+const write = (relative) => {
+  const full = path.join(root, relative)
+  fs.mkdirSync(path.dirname(full), { recursive: true })
+  fs.writeFileSync(full, 'x')
+  return full
+}
+
+const EXT = ['exe', 'html', 'swf']
+
+describe('findExecutables', () => {
+  it('finds a launcher sitting at the root', async () => {
+    write('Game.exe')
+    expect(await findExecutables(root, EXT)).toEqual(['Game.exe'])
+  })
+
+  it('descends when the root has nothing, which is the RenPy layout', async () => {
+    write('game/script.rpy')
+    write('lib/Game.exe')
+    expect(await findExecutables(root, EXT)).toEqual([path.join('lib', 'Game.exe')])
+  })
+
+  it('stops the whole walk once a directory yields a match', async () => {
+    // The root answers, so nothing below it should be read at all. Proven by
+    // making the subtree unreadable: a walk that descended would log a warning
+    // for it, and an older walk that kept collecting would return its contents.
+    write('Game.exe')
+    write('data/deep/Other.exe')
+    const found = await findExecutables(root, EXT)
+    expect(found).toEqual(['Game.exe'])
+    expect(found.some((entry) => entry.includes('data'))).toBe(false)
+  })
+
+  it('prefers the shallowest match rather than whichever branch it wandered into', async () => {
+    // Breadth-first matters because every caller takes [0]. The old depth-first
+    // stack could return a bundled runtime binary from three levels down while
+    // the real launcher sat one level up.
+    write('bin/runtime/nested/Deep.exe')
+    write('top/Launcher.exe')
+    expect(await findExecutables(root, EXT)).toEqual([path.join('top', 'Launcher.exe')])
+  })
+
+  it('returns a stable first candidate when one folder holds several', async () => {
+    // [0] is what the install stores as the exec path. Filesystem order is not
+    // guaranteed, so without sorting the same folder could install a different
+    // launcher on different machines.
+    write('zeta.exe')
+    write('alpha.exe')
+    write('middle.exe')
+    const found = await findExecutables(root, EXT)
+    expect(found[0]).toBe('alpha.exe')
+    expect(found).toEqual(['alpha.exe', 'middle.exe', 'zeta.exe'])
+  })
+
+  it('ignores the 32-bit twin that ships beside the real launcher', async () => {
+    write('Game-32.exe')
+    write('Game.exe')
+    expect(await findExecutables(root, EXT)).toEqual(['Game.exe'])
+  })
+
+  it('ignores files whose extension is not configured', async () => {
+    write('readme.txt')
+    write('data.bin')
+    expect(await findExecutables(root, EXT)).toEqual([])
+  })
+
+  it('reports nothing rather than throwing when the folder does not exist', async () => {
+    expect(await findExecutables(path.join(root, 'not-here'), EXT)).toEqual([])
+  })
+
+  it('reports nothing when no extensions are configured', async () => {
+    // A caller with an empty extension list would otherwise walk the entire
+    // tree to match nothing - the worst case, for no possible result.
+    write('Game.exe')
+    expect(await findExecutables(root, [])).toEqual([])
+  })
+
+  it('skips an unreadable subfolder instead of failing the install', async () => {
+    // Faked rather than chmod'd: CI and this container both run as root, where
+    // chmod 000 is not a permission denial at all and the test would pass
+    // without ever reaching the catch it is meant to cover.
+    write('locked/Hidden.exe')
+    write('open/Game.exe')
+    const real = fs.promises.readdir
+    const denied = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+    const spy = vi.spyOn(fs.promises, 'readdir').mockImplementation((target, options) => {
+      if (String(target).endsWith('locked')) return Promise.reject(denied)
+      return real.call(fs.promises, target, options)
+    })
+    try {
+      // The install must still get its executable from the folder it CAN read.
+      await expect(findExecutables(root, EXT)).resolves.toEqual([path.join('open', 'Game.exe')])
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('normalises extensions given with dots or odd casing', async () => {
+    write('Game.EXE')
+    expect(await findExecutables(root, ['.Exe'])).toEqual(['Game.EXE'])
+  })
+
+  // ── The regression this rewrite exists for ─────────────────────────────────
+  it('yields to the event loop while walking instead of blocking it', async () => {
+    // A deep tree with NO match anywhere, which is the pathological case: the
+    // walk cannot stop early and must read every directory.
+    //
+    // A timer scheduled before the walk starts must be able to fire while it
+    // runs. Under the old readdirSync implementation the event loop was blocked
+    // end to end, so the timer could not fire until the walk had finished, and
+    // this counter would read 0.
+    let deep = ''
+    for (let level = 0; level < 40; level += 1) {
+      deep = path.join(deep, `level${level}`)
+      for (let file = 0; file < 25; file += 1) write(path.join(deep, `file${file}.txt`))
+    }
+
+    let ticks = 0
+    const timer = setInterval(() => { ticks += 1 }, 1)
+    try {
+      const found = await findExecutables(root, EXT)
+      expect(found).toEqual([])
+    } finally {
+      clearInterval(timer)
+    }
+
+    expect(ticks).toBeGreaterThan(0)
+  })
+})

--- a/tests/install-library-refresh.test.js
+++ b/tests/install-library-refresh.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+// ── Install must not re-validate the whole library ───────────────────────────
+//
+// getGames maps EVERY version of EVERY game through mapVersionRow
+// (electron/db/versions.js), which without skipPathValidation runs a
+// synchronous fs.existsSync on both game_path and exec_path. Two blocking stats
+// per version, across the entire library, on the main process.
+//
+// On an SSD that is invisible, which is exactly why it shipped. A user with
+// ~6000 games on a mechanical drive reported the app locking up after every
+// install with "all version folders are being scanned" in Resource Monitor.
+// They were right.
+//
+// Path validation is meant to be the deliberate pass in validate-library-paths:
+// one record at a time, yielding every 25, gated behind
+// Library.validatePathsOnStartup and only ever fired from requestIdleCallback.
+// Finishing an install is not a request to re-verify everything on disk.
+//
+// This reads the source rather than mounting App, because the bug is not in any
+// function's behaviour - fetchGames does exactly what it is asked - it is in
+// what the call site asks for. A behavioural test would have to mount the whole
+// application and count stat calls to see it. The wiring is the thing worth
+// pinning, so the wiring is what this reads.
+
+const appSource = fs.readFileSync(
+  path.join(process.cwd(), 'src', 'App.jsx'),
+  'utf8',
+)
+
+// The props passed to InstallFlowHost, isolated from the rest of the file.
+function installFlowHostProps() {
+  const start = appSource.indexOf('<InstallFlowHost')
+  if (start === -1) return null
+  const end = appSource.indexOf('/>', start)
+  if (end === -1) return null
+  return appSource.slice(start, end)
+}
+
+describe('the install completion handler', () => {
+  it('is still wired up at all', () => {
+    // If InstallFlowHost is renamed or unmounted, the assertions below would
+    // pass vacuously on an empty string and this guard would quietly stop
+    // guarding anything.
+    const props = installFlowHostProps()
+    expect(props).toBeTruthy()
+    expect(props).toContain('onInstalled')
+  })
+
+  it('refreshes the library without re-validating every path on disk', () => {
+    const props = installFlowHostProps()
+    expect(props).toContain('fetchGames(')
+    expect(props).toContain('skipPathValidation: true')
+  })
+
+  it('does not call fetchGames bare, which is what caused the freeze', () => {
+    // `fetchGames()` with no options defaults skipPathValidation to false. That
+    // single missing argument is the entire bug.
+    const props = installFlowHostProps()
+    expect(props).not.toMatch(/fetchGames\(\s*\)/)
+  })
+})

--- a/tests/mega-host.test.js
+++ b/tests/mega-host.test.js
@@ -622,3 +622,64 @@ describe('the MAC is CBC, and identical to the per-block definition', () => {
     expect(second.verify()).toBe(true)
   })
 })
+
+describe('entryError — the two shapes MEGA reports failures in', () => {
+  // The bug this covers: a deleted file comes back as `[{"e": -9}]`, an OBJECT
+  // carrying the code, not the bare `[-9]` the code was written for. The object
+  // shape fell through to "MEGA's response did not include a download URL" and
+  // was classified TRANSIENT, so Atlas retried a permanently dead link forever
+  // instead of telling the user the file was gone.
+
+  it('reads a deleted file reported as a bare code', () => {
+    expect(mega.entryError(-9)).toMatchObject({
+      kind: 'fatal', message: 'This MEGA file no longer exists.', code: -9, shape: 'bare',
+    })
+  })
+
+  it('reads a deleted file reported inside the entry object', () => {
+    expect(mega.entryError({ e: -9 })).toMatchObject({
+      kind: 'fatal', message: 'This MEGA file no longer exists.', code: -9, shape: 'entry.e',
+    })
+  })
+
+  it('classifies a deleted file as fatal, not as something worth retrying', () => {
+    // The kind is what decides whether the queue retries. Getting this wrong is
+    // why a dead link never settled into a final state.
+    expect(mega.entryError({ e: -9 }).kind).toBe('fatal')
+    expect(mega.entryError({ e: -11 }).kind).toBe('fatal')
+    expect(mega.entryError({ e: -16 }).kind).toBe('fatal')
+  })
+
+  it('still routes genuinely temporary codes as transient in either shape', () => {
+    expect(mega.entryError({ e: -3 }).kind).toBe('transient')
+    expect(mega.entryError(-3).kind).toBe('transient')
+    expect(mega.entryError({ e: -17 }).kind).toBe('quota')
+    expect(mega.entryError({ e: -15 }).kind).toBe('auth')
+  })
+
+  it('passes a successful entry through untouched', () => {
+    expect(mega.entryError({ g: 'https://gfs.mega.nz/dl/abc', s: 1024 })).toBeNull()
+  })
+
+  it('does not invent an error from a missing or empty e', () => {
+    // Number(undefined) is NaN but Number(null) and Number('') are both 0, and
+    // 0 is MEGA's SUCCESS code — a naive Number(entry.e) turns "no error here"
+    // into "error 0" and fails a download that worked.
+    expect(mega.entryError({ g: 'https://gfs.mega.nz/dl/abc' })).toBeNull()
+    expect(mega.entryError({ e: null, g: 'https://gfs.mega.nz/dl/abc' })).toBeNull()
+    expect(mega.entryError({ e: '', g: 'https://gfs.mega.nz/dl/abc' })).toBeNull()
+    expect(mega.entryError({ e: 0, g: 'https://gfs.mega.nz/dl/abc' })).toBeNull()
+  })
+
+  it('describes an unknown code rather than dropping it', () => {
+    const unknown = mega.entryError({ e: -99 })
+    expect(unknown.message).toContain('-99')
+    expect(unknown.kind).toBe('transient')
+  })
+
+  it('ignores shapes that carry no error at all', () => {
+    expect(mega.entryError(null)).toBeNull()
+    expect(mega.entryError(undefined)).toBeNull()
+    expect(mega.entryError('a string')).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #349

## Changes

- Removed the "Has Steam mapping" quick filter.
- Steam URL searching is already supported.

## Tests

- npm run check
- All tests passed.