### PR TITLE
[ATLAS-132] Make the file path input to be editable in existing config locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+- Allow setting folder and program locations by typing or paste a path directly besides using Browse / Select Folder button. 
+  - Affected locations:  Atlas Importer, Library path settings,and Emulators. The 7z field path is not touched as it have more requirements than the based one.
+  - Path resolution highlighting: red if invalid, green if path exists or pass the check.
+  
 ### Added
 - Custom media uploads in the Game Details Media tab: add preview images from local files, a drag-and-drop zone, or an image URL, with live progress. Previews can be reordered by drag and the order persists in a new `preview_sort` table keyed by remote URL (or relative path for custom uploads), so it survives re-downloads, stream/download switches and metadata refreshes. Previews now carry a source logo and a storage-location badge, and custom previews can be deleted independently of downloaded ones.
 - Add Buzzheavier host support (`buzzheavier.com`, `bzzhr.to`, `bzzhr.co`). The download route is behind a Cloudflare challenge, so the resolve runs in a browser window: it clicks the htmx download button, captures the `HX-Redirect` (or an attachment via `will-download`), and hands the resolved CDN link plus the browser's own cookies/UA back to the downloader. The resolve partition is persistent so a solved challenge survives a restart -- only Cloudflare's own challenge cookies are kept, everything else is stripped after each resolve -- and resolves run one at a time, since a shared session cannot carry two concurrently. Each time your IP changes there is a brief auto-resolve window while the challenge is re-solved.

--- a/electron/ipc/windows.js
+++ b/electron/ipc/windows.js
@@ -349,6 +349,25 @@ module.exports = function registerWindowsHandlers(ctx) {
     }
   })
 
+  // Inline-editable path fields type directly into the input. The renderer has
+  // no fs access, so it asks the main process to stat the path. Returns
+  // {exists,isDirectory,isFile} so the caller can enforce file vs directory and
+  // absolute-path rules without trusting the renderer. Any error is invalid, not thrown.
+  ipcMain.handle('check-path', async (_event, raw) => {
+    const p = String(raw || '').trim().replace(/^["']|["']$/g, '')
+    if (!p) return { exists: false }
+    // Relative paths must not resolve against the app's cwd — only absolute paths
+    // (including UNC on Windows) are user-meaningful here.
+    if (!path.isAbsolute(p)) return { exists: false }
+    try {
+      const st = await fs.promises.stat(p)
+      return { exists: true, isDirectory: st.isDirectory(), isFile: st.isFile() }
+    } catch (e) {
+      if (e && e.code === 'ENOENT') return { exists: false }
+      return { exists: false, error: String(e && e.message || e) }
+    }
+  })
+
   // Cross-screen color picker support. Captures every display at full
   // resolution and returns each as a PNG data URL along with its logical
   // bounds and scale factor. The renderer overlays these captures fullscreen

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -68,6 +68,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     console.log("Invoking selectDirectory");
     return ipcRenderer.invoke("select-directory", options);
   },
+  checkPath: (p) => ipcRenderer.invoke("check-path", p),
   getVersion: () => ipcRenderer.invoke("get-version"),
   openSettings: (options) => ipcRenderer.invoke("open-settings", options),
   onStartSettingsTour: (cb) => {

--- a/src/components/importer/Importer.jsx
+++ b/src/components/importer/Importer.jsx
@@ -1025,6 +1025,15 @@ const Importer = () => {
     }
   }
 
+  // Pure picker for the inline-editable Game Path field. Unlike selectFolder
+  // it does not write to state itself — the field's onSave handles that after
+  // validation, or the picker result is committed directly.
+  const pickScanFolder = () => window.electronAPI.selectDirectory({
+    title: 'Select the folder to scan for games',
+    message: 'Choose the folder that contains the games (or archives) you want to import.',
+    buttonLabel: 'Scan this folder',
+  })
+
   const handleCustomFormatChange = (value) => {
     setCustomFormat(value)
     saveImporterDefaults({ sourceFolderStructure: value })
@@ -1951,7 +1960,7 @@ const Importer = () => {
               autoSelectLatestReplaceVersion={autoSelectLatestReplaceVersion}
               defaultLibraryPath={defaultLibraryPath} askingForLibraryFolder={askingForLibraryFolder}
               libraryFormat={libraryFormat} setLibraryFormat={handleLibraryFormatChange}
-              onSelectFolder={selectFolder} onStartScan={startScan}
+              onSelectFolder={selectFolder} onPickScanFolder={pickScanFolder} setFolder={setFolder} saveImporterDefaults={saveImporterDefaults} onStartScan={startScan}
               onOpenHelp={openImporterHelp}
               livePreview={livePreview}
               setCustomFormat={handleCustomFormatChange} setUseUnstructured={handleUseUnstructuredChange}

--- a/src/components/importer/steps/SettingsStep.jsx
+++ b/src/components/importer/steps/SettingsStep.jsx
@@ -1,4 +1,5 @@
 import { buildFolderRegex } from '../folderRegex.js'
+import EditablePathField from '../../ui/EditablePathField.jsx'
 
 // Checkbox + label row used throughout the settings form. Defined at module
 // scope so it isn't re-created (and its children re-mounted) on every render.
@@ -18,7 +19,7 @@ export default function SettingsStep({
   moveFoldersToLibrary, deleteSourceArchiveAfterImport, autoSelectLatestReplaceVersion,
   defaultLibraryPath, askingForLibraryFolder,
   libraryFormat, setLibraryFormat,
-  onSelectFolder, onStartScan, onOpenHelp, livePreview,
+  onSelectFolder, onPickScanFolder, setFolder, saveImporterDefaults, onStartScan, onOpenHelp, livePreview,
   setCustomFormat, setUseUnstructured, setGameExt, setArchiveExt,
   setIncludeArchives, setUseCustomRegex, setCustomRegex,
   setDownloadBannerImages, setDownloadPreviewImages, setMoveFoldersToLibrary,
@@ -62,10 +63,14 @@ export default function SettingsStep({
     <div className="space-y-4 flex-1">
       <div className={fieldRow}>
         <label className={fieldLabel}>Game Path:</label>
-        <input type="text" value={folder} readOnly className="sm:ml-2 flex-1 min-w-0 bg-secondary text-text border border-border rounded-buttonTheme p-1 focus:outline-none focus:ring-1 focus:ring-accent" />
-        <button onClick={onSelectFolder} className="sm:ml-2 bg-accent hover:bg-accentHover text-white rounded-buttonTheme px-3 py-1 transition-colors" style={{ pointerEvents: 'auto', zIndex: 1000 }}>
-          Set Folder
-        </button>
+        <EditablePathField
+          value={folder}
+          mode="directory"
+          pickerLabel="Set Folder"
+          onPick={onPickScanFolder || onSelectFolder}
+          onSave={(p) => { setFolder?.(p); saveImporterDefaults?.({ sourceGamePath: p }) }}
+          wrapperClassName="sm:ml-2 flex-1 min-w-0 flex gap-2"
+        />
       </div>
 
       <div className={fieldRow}>

--- a/src/components/settings/EmulatorLauncher.jsx
+++ b/src/components/settings/EmulatorLauncher.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import EditablePathField from '../ui/EditablePathField.jsx'
 
 // Two ways to point a launcher at a game, because ".sh" and "game.sh" are
 // different questions. The extension mapping is the broad rule — run every
@@ -85,18 +86,6 @@ const EmulatorLauncher = () => {
     } catch (err) {
       console.error("Error saving emulator config:", err);
       alert("Failed to save emulator configuration.");
-    }
-  };
-
-  // Handle selecting a program file
-  const handleSelectProgram = async () => {
-    try {
-      const filePath = await window.electronAPI.selectFile();
-      if (filePath) {
-        setProgramPath(filePath);
-      }
-    } catch (err) {
-      console.error("Error selecting program:", err);
     }
   };
 
@@ -199,22 +188,15 @@ const EmulatorLauncher = () => {
             <label className="block text-sm font-medium text-text mb-1">
               Program Path
             </label>
-            <div className="flex flex-col sm:flex-row gap-2">
-              <input
-                type="text"
-                value={programPath}
-                readOnly
-                placeholder="Select a program"
-                className="w-full p-2 bg-primary border border-border text-text rounded focus:outline-none"
-              />
-              <button
-                type="button"
-                onClick={handleSelectProgram}
-                className="p-2 bg-accent text-text rounded hover:bg-accentHover whitespace-nowrap"
-              >
-                Browse
-              </button>
-            </div>
+            <EditablePathField
+              value={programPath}
+              mode="file"
+              placeholder="Select a program"
+              pickerLabel="Browse"
+              onPick={() => window.electronAPI.selectFile()}
+              onSave={setProgramPath}
+              wrapperClassName="flex flex-col sm:flex-row gap-2"
+            />
           </div>
           <div>
             <label className="block text-sm font-medium text-text mb-1">

--- a/src/components/settings/Library.jsx
+++ b/src/components/settings/Library.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { saveLibrarySetting, saveLibrarySettings, pickGameFolder } from '../../utils/librarySettings.js'
+import { saveLibrarySetting, saveLibrarySettings } from '../../utils/librarySettings.js'
+import EditablePathField from '../ui/EditablePathField.jsx'
 
 // Library.jsx  (updated)
 //
@@ -71,22 +72,6 @@ const Library = () => {
     });
     return () => window.electronAPI.removeAllListeners?.("library-validation-progress");
   }, []);
-
-  const handleSetGameFolder = async () => {
-    // pickGameFolder persists the choice itself, so there is no saveLibrarySetting
-    // call here — that is the point of sharing it. An empty return is a cancelled
-    // dialog and must not clear a folder that is already set.
-    const path = await pickGameFolder();
-    if (path) setGameFolder(path);
-  };
-
-  const handleSetDownloadsFolder = async () => {
-    const path = await window.electronAPI.selectDirectory();
-    if (path) {
-      setDownloadsFolder(path);
-      saveLibrarySetting("downloadsFolder", path);
-    }
-  };
 
   // Clearing falls back to the OS downloads directory rather than to a folder
   // inside the library, which must never hold in-progress archives.
@@ -217,20 +202,14 @@ const Library = () => {
       {/* Default Game Folder */}
       <div data-tour="LibraryFolder">
         <label className="block mb-1">Default Game Folder</label>
-        <div className="flex gap-3">
-          <input
-            type="text"
-            className="flex-1 bg-secondary border border-border p-2 rounded"
-            value={gameFolder}
-            readOnly
-          />
-          <button
-            onClick={handleSetGameFolder}
-            className="bg-accent px-5 py-2 rounded hover:bg-accentHover"
-          >
-            Set Folder
-          </button>
-        </div>
+        <EditablePathField
+          data-tour="LibraryFolder"
+          value={gameFolder}
+          mode="directory"
+          pickerLabel="Set Folder"
+          onPick={() => window.electronAPI.selectDirectory()}
+          onSave={(p) => { setGameFolder(p); saveLibrarySetting('gameFolder', p) }}
+        />
         <p className="text-xs opacity-60 mt-1">
           Newly imported / extracted games will be placed here.
         </p>
@@ -240,19 +219,15 @@ const Library = () => {
       <div>
         <label className="block mb-1">Downloads Folder</label>
         <div className="flex gap-3">
-          <input
-            type="text"
-            className="flex-1 bg-secondary border border-border p-2 rounded"
+          <EditablePathField
             value={downloadsFolder}
+            mode="directory"
+            allowEmpty
             placeholder="Default: your system Downloads folder"
-            readOnly
+            pickerLabel="Set Folder"
+            onPick={() => window.electronAPI.selectDirectory()}
+            onSave={(p) => { setDownloadsFolder(p); saveLibrarySetting('downloadsFolder', p) }}
           />
-          <button
-            onClick={handleSetDownloadsFolder}
-            className="bg-accent px-5 py-2 rounded hover:bg-accentHover"
-          >
-            Set Folder
-          </button>
           {downloadsFolder && (
             <button
               onClick={handleClearDownloadsFolder}

--- a/src/components/ui/EditablePathField.jsx
+++ b/src/components/ui/EditablePathField.jsx
@@ -1,0 +1,188 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+
+// Inline-editable path field shared by the four locations that let the user
+// type a filesystem path directly (Importer Game Path, Library Default Game
+// Folder, Library Downloads Folder, Emulator Program Path).
+//
+// Why controlled: the parent (Library.jsx, Importer.jsx, EmulatorLauncher.jsx)
+// is the source of truth for the saved path. A controlled value lets the Reset
+// button and the `onLibraryValidationProgress` subscription push a new value
+// in without the field having to be reset manually. The `draft` is only the
+// in-progress edit; `value` is what is persisted.
+//
+// Why picker bypasses IPC: a native dialog already guarantees existence and
+// absoluteness, so re-statting it is wasted work and would flicker the error
+// state on a slow drive.
+//
+// Why validating flag: blur and Enter can both fire for the same commit
+// (Enter then blur). Without a guard the IPC runs twice and the second can
+// overwrite the first.
+export default function EditablePathField({
+  value = '',
+  mode = 'directory',
+  allowEmpty = false,
+  placeholder = '',
+  pickerLabel = 'Set Folder',
+  onPick,
+  onSave,
+  'data-tour': dataTour,
+  wrapperClassName,
+  inputClassName,
+}) {
+  const inputRef = useRef(null)
+  const pickingRef = useRef(false)
+  const successTimerRef = useRef(null)
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [error, setError] = useState(false)
+  const [validating, setValidating] = useState(false)
+  const [success, setSuccess] = useState(false)
+
+  // Keep draft in sync when parent value changes and we are not editing.
+  // While editing the user's keystrokes own the draft.
+  useEffect(() => {
+    if (!editing) setDraft(value)
+  }, [value, editing])
+
+  // Clear success flash timer on unmount
+  useEffect(() => () => {
+    if (successTimerRef.current) clearTimeout(successTimerRef.current)
+  }, [])
+
+  const flashSuccess = useCallback(() => {
+    setSuccess(true)
+    if (successTimerRef.current) clearTimeout(successTimerRef.current)
+    successTimerRef.current = setTimeout(() => setSuccess(false), 450)
+  }, [])
+
+  const enterEdit = useCallback(() => {
+    if (editing) return
+    setEditing(true)
+    setDraft(value)
+    setError(false)
+    setSuccess(false)
+    if (successTimerRef.current) clearTimeout(successTimerRef.current)
+    // Select all so typing replaces the whole path quickly (e.g. I:\XLibrary\RPGM).
+    requestAnimationFrame(() => inputRef.current?.select())
+  }, [editing, value])
+
+  const doCommit = useCallback(async ({ keepFocus }) => {
+    if (!editing || validating) return
+    const trimmed = String(draft).trim().replace(/^["']|["']$/g, '')
+    // Empty is only valid for Downloads Folder (allowEmpty).
+    if (allowEmpty && trimmed === '') {
+      setError(false)
+      setEditing(false)
+      setValidating(false)
+      flashSuccess()
+      onSave?.('')
+      return
+    }
+    if (!trimmed) {
+      setError(true)
+      if (keepFocus) inputRef.current?.focus()
+      return
+    }
+    setValidating(true)
+    let result = null
+    try {
+      result = await window.electronAPI?.checkPath?.(trimmed)
+    } catch {
+      result = { exists: false }
+    }
+    setValidating(false)
+    const exists = Boolean(result?.exists)
+    const isDir = Boolean(result?.isDirectory)
+    const isFile = Boolean(result?.isFile)
+    const valid = mode === 'file' ? exists && isFile : exists && isDir
+    if (valid) {
+      setError(false)
+      setEditing(false)
+      flashSuccess()
+      onSave?.(trimmed)
+    } else {
+      setError(true)
+      // Stay in edit mode; blur drops focus but error+draft persist.
+      if (keepFocus) inputRef.current?.focus()
+    }
+  }, [editing, validating, draft, allowEmpty, mode, onSave, flashSuccess])
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      doCommit({ keepFocus: true })
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      setDraft(value)
+      setError(false)
+      setEditing(false)
+      setValidating(false)
+      setSuccess(false)
+      if (successTimerRef.current) clearTimeout(successTimerRef.current)
+    }
+  }, [doCommit, value])
+
+  const handleBlur = useCallback(() => {
+    // Picker click causes blur before click; suppress commit so the picked
+    // native path is used directly without an intervening validation.
+    if (pickingRef.current) return
+    doCommit({ keepFocus: false })
+  }, [doCommit])
+
+  const handlePick = useCallback(async () => {
+    pickingRef.current = true
+    try {
+      const picked = await onPick?.()
+      if (picked) {
+        setError(false)
+        setEditing(false)
+        setDraft(picked)
+        setValidating(false)
+        flashSuccess()
+        onSave?.(picked)
+      }
+    } finally {
+      // Let blur handler see the flag, then clear it.
+      setTimeout(() => { pickingRef.current = false }, 0)
+    }
+  }, [onPick, onSave, flashSuccess])
+
+  const baseInput = 'flex-1 min-w-0 p-2 rounded border focus:outline-none transition-colors duration-300'
+  const stateClass = error
+    ? 'bg-primary border-danger ring-1 ring-danger/60 shadow-[0_0_8px_rgba(239,68,68,0.35)]'
+    : success
+      ? 'bg-secondary border-emerald-500 ring-1 ring-green-500/60 shadow-[0_0_8px_rgba(16,185,129,0.4)]'
+      : editing
+        ? 'bg-primary border-accent focus:ring-1 focus:ring-accent'
+        : 'bg-secondary border-border'
+  const validatingClass = validating ? ' opacity-60 cursor-wait' : ''
+
+  return (
+    <div
+      data-tour={dataTour}
+      className={wrapperClassName || 'flex gap-3 flex-1 min-w-0'}
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={editing ? draft : (value ?? '')}
+        readOnly={!editing}
+        placeholder={placeholder}
+        onFocus={enterEdit}
+        onClick={enterEdit}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+        className={`${baseInput} ${stateClass}${validatingClass} ${inputClassName || ''}`.trim()}
+      />
+      <button
+        type="button"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={handlePick}
+        className="bg-accent px-5 py-2 rounded hover:bg-accentHover whitespace-nowrap shrink-0"
+      >
+        {pickerLabel}
+      </button>
+    </div>
+  )
+}

--- a/tests/check-path.test.js
+++ b/tests/check-path.test.js
@@ -1,0 +1,89 @@
+import { test, expect, vi } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+// Replicate the handler logic from electron/ipc/windows.js for isolated unit testing.
+// This mirrors the actual `check-path` handler so the spec (trimming, quote
+// stripping, isAbsolute guard, stat handling) is tested without needing to boot
+// the Electron main process. The handler source is also asserted to exist in
+// windows.js via a string check.
+
+function normalize(raw) {
+  return String(raw || '').trim().replace(/^["']|["']$/g, '')
+}
+
+async function checkPath(raw) {
+  const p = normalize(raw)
+  if (!p) return { exists: false }
+  if (!path.isAbsolute(p)) return { exists: false }
+  try {
+    const st = await fs.promises.stat(p)
+    return { exists: true, isDirectory: st.isDirectory(), isFile: st.isFile() }
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return { exists: false }
+    return { exists: false, error: String(e && e.message || e) }
+  }
+}
+
+test('windows handler file actually registers check-path', async () => {
+  const src = await fs.promises.readFile(path.join(process.cwd(), 'electron/ipc/windows.js'), 'utf8')
+  expect(src).toContain("ipcMain.handle('check-path'")
+  expect(src).toContain('path.isAbsolute')
+})
+
+test('returns exists:false for empty and whitespace input without touching fs', async () => {
+  const statSpy = vi.spyOn(fs.promises, 'stat')
+  expect(await checkPath('')).toEqual({ exists: false })
+  expect(await checkPath('   ')).toEqual({ exists: false })
+  expect(await checkPath(null)).toEqual({ exists: false })
+  expect(statSpy).not.toHaveBeenCalled()
+  statSpy.mockRestore()
+})
+
+test('strips surrounding quotes and trims before stat', async () => {
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'atlas-check-path-'))
+  try {
+    expect(await checkPath(`"${tmpDir}"`)).toEqual({ exists: true, isDirectory: true, isFile: false })
+    expect(await checkPath(`'${tmpDir}'`)).toEqual({ exists: true, isDirectory: true, isFile: false })
+    expect(await checkPath(`  ${tmpDir}  `)).toEqual({ exists: true, isDirectory: true, isFile: false })
+  } finally {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('returns isDirectory true for an existing directory and isFile for a file', async () => {
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'atlas-check-path-'))
+  const tmpFile = path.join(tmpDir, 'file.txt')
+  await fs.promises.writeFile(tmpFile, 'hello')
+  try {
+    expect(await checkPath(tmpDir)).toMatchObject({ exists: true, isDirectory: true, isFile: false })
+    expect(await checkPath(tmpFile)).toMatchObject({ exists: true, isDirectory: false, isFile: true })
+  } finally {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('returns exists:false for ENOENT (missing path)', async () => {
+  const missing = path.join(os.tmpdir(), `atlas-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  const result = await checkPath(missing)
+  expect(result.exists).toBe(false)
+  expect(result.isDirectory).toBeUndefined()
+})
+
+test('rejects relative paths as invalid without calling stat', async () => {
+  const statSpy = vi.spyOn(fs.promises, 'stat')
+  expect(await checkPath('relative/path')).toEqual({ exists: false })
+  expect(statSpy).not.toHaveBeenCalled()
+  statSpy.mockRestore()
+  expect(await checkPath('foo.txt')).toEqual({ exists: false })
+})
+
+test('returns exists:false for non-ENOENT errors without throwing', async () => {
+  const statSpy = vi.spyOn(fs.promises, 'stat').mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+  const p = path.isAbsolute('/tmp') ? '/tmp' : 'C:\\Windows'
+  const result = await checkPath(p)
+  expect(result.exists).toBe(false)
+  expect(result.error).toBeDefined()
+  statSpy.mockRestore()
+})

--- a/tests/editable-path-field.test.jsx
+++ b/tests/editable-path-field.test.jsx
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import { test, expect, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, act, fireEvent } from '@testing-library/react'
+import { useState } from 'react'
+
+import EditablePathField from '../src/components/ui/EditablePathField.jsx'
+
+beforeEach(() => {
+  cleanup()
+  const fakeCheck = async (p) => {
+    const trimmed = String(p).trim().replace(/^["']|["']$/g, '')
+    if (!trimmed) return { exists: false }
+    if (trimmed === '/tmp/games' || trimmed === '/tmp/valid' || trimmed === 'C:/Games') {
+      return { exists: true, isDirectory: true, isFile: false }
+    }
+    if (trimmed === '/usr/bin/app' || trimmed === 'C:/Programs/app.exe') {
+      return { exists: true, isDirectory: false, isFile: true }
+    }
+    if (trimmed === '/tmp/file.txt') {
+      return { exists: true, isDirectory: false, isFile: true }
+    }
+    return { exists: false }
+  }
+  vi.stubGlobal('window', {
+    electronAPI: {
+      checkPath: vi.fn(fakeCheck),
+      selectDirectory: vi.fn(async () => null),
+      selectFile: vi.fn(async () => null),
+    },
+  })
+})
+
+const renderSettled = async (ui) => {
+  let result
+  await act(async () => { result = render(ui) })
+  return result
+}
+
+// Helper that mimics a controlled parent updating value on onSave
+function StatefulWrapper({ initialValue, ...props }) {
+  const [val, setVal] = useState(initialValue)
+  const onSave = vi.fn((p) => {
+    setVal(p)
+    props.onSave?.(p)
+  })
+  // expose spy via props
+  return <EditablePathField {...props} value={val} onSave={onSave} />
+}
+
+test('enters edit on focus and can commit a valid directory via Enter (stateful parent)', async () => {
+  const onSave = vi.fn()
+  const { container } = await renderSettled(
+    <StatefulWrapper initialValue="/tmp/old" mode="directory" pickerLabel="Set Folder" onPick={async () => null} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  expect(input.readOnly).toBe(true)
+  await act(async () => { fireEvent.focus(input) })
+  expect(input.readOnly).toBe(false)
+  await act(async () => { fireEvent.change(input, { target: { value: '/tmp/games' } }) })
+  await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)) })
+  expect(window.electronAPI.checkPath).toHaveBeenCalledWith('/tmp/games')
+  expect(onSave).toHaveBeenCalledWith('/tmp/games')
+  expect(input.readOnly).toBe(true)
+  // parent state updated, so input now shows new value
+  expect(input.value).toBe('/tmp/games')
+})
+
+test('valid blur also commits', async () => {
+  const onSave = vi.fn()
+  const { container } = await renderSettled(
+    <EditablePathField value="/tmp/old" mode="directory" onPick={async () => null} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  await act(async () => { fireEvent.focus(input) })
+  await act(async () => { fireEvent.change(input, { target: { value: '/tmp/games' } }) })
+  await act(async () => { fireEvent.blur(input) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)) })
+  expect(onSave).toHaveBeenCalledWith('/tmp/games')
+})
+
+test('invalid keeps error border, does not call onSave, stays in edit', async () => {
+  const onSave = vi.fn()
+  const { container } = await renderSettled(
+    <EditablePathField value="/tmp/old" mode="directory" onPick={async () => null} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  await act(async () => { fireEvent.focus(input) })
+  await act(async () => { fireEvent.change(input, { target: { value: '/tmp/does-not-exist' } }) })
+  await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)) })
+  expect(onSave).not.toHaveBeenCalled()
+  expect(input.readOnly).toBe(false)
+  expect(input.className).toMatch(/border-danger/)
+  window.electronAPI.checkPath.mockClear()
+  await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)) })
+  expect(window.electronAPI.checkPath).toHaveBeenCalled()
+  expect(onSave).not.toHaveBeenCalled()
+})
+
+test('blur on invalid drops focus but keeps error and draft', async () => {
+  const onSave = vi.fn()
+  const { container } = await renderSettled(
+    <EditablePathField value="/tmp/old" mode="directory" onPick={async () => null} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  await act(async () => { fireEvent.focus(input) })
+  await act(async () => { fireEvent.change(input, { target: { value: '/tmp/bad' } }) })
+  await act(async () => { fireEvent.blur(input) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)) })
+  expect(onSave).not.toHaveBeenCalled()
+  expect(document.activeElement).not.toBe(input)
+  expect(input.className).toMatch(/border-danger/)
+  expect(input.value).toBe('/tmp/bad')
+  await act(async () => { fireEvent.focus(input) })
+  expect(input.value).toBe('/tmp/bad')
+})
+
+test('Escape while invalid reverts to value and clears error', async () => {
+  const onSave = vi.fn()
+  const { container } = await renderSettled(
+    <EditablePathField value="/tmp/old" mode="directory" onPick={async () => null} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  await act(async () => { fireEvent.focus(input) })
+  await act(async () => { fireEvent.change(input, { target: { value: '/tmp/bad' } }) })
+  await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)) })
+  expect(input.className).toMatch(/border-danger/)
+  await act(async () => { fireEvent.keyDown(input, { key: 'Escape' }) })
+  expect(input.readOnly).toBe(true)
+  expect(input.value).toBe('/tmp/old')
+  expect(input.className).not.toMatch(/border-danger/)
+  expect(onSave).not.toHaveBeenCalled()
+})
+
+test('allowEmpty accepts "" without IPC', async () => {
+  const onSave = vi.fn()
+  const { container } = await renderSettled(
+    <EditablePathField value="/tmp/old" mode="directory" allowEmpty onPick={async () => null} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  await act(async () => { fireEvent.focus(input) })
+  await act(async () => { fireEvent.change(input, { target: { value: '   ' } }) })
+  await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 15)) })
+  expect(window.electronAPI.checkPath).not.toHaveBeenCalled()
+  expect(onSave).toHaveBeenCalledWith('')
+})
+
+test('file vs directory mismatch is invalid', async () => {
+  const onSave = vi.fn()
+  const { container } = await renderSettled(
+    <EditablePathField value="/tmp/old" mode="directory" onPick={async () => null} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  await act(async () => { fireEvent.focus(input) })
+  await act(async () => { fireEvent.change(input, { target: { value: '/tmp/file.txt' } }) })
+  await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)) })
+  expect(onSave).not.toHaveBeenCalled()
+  expect(input.className).toMatch(/border-danger/)
+})
+
+test('file mode valid when isFile', async () => {
+  const onSave = vi.fn()
+  const { container } = await renderSettled(
+    <EditablePathField value="" mode="file" onPick={async () => null} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  await act(async () => { fireEvent.focus(input) })
+  await act(async () => { fireEvent.change(input, { target: { value: '/usr/bin/app' } }) })
+  await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)) })
+  expect(onSave).toHaveBeenCalledWith('/usr/bin/app')
+})
+
+test('onPick returning a path calls onSave without checkPath', async () => {
+  const onSave = vi.fn()
+  const onPick = vi.fn(async () => '/tmp/games')
+  await renderSettled(
+    <EditablePathField value="/tmp/old" mode="directory" pickerLabel="Set Folder" onPick={onPick} onSave={onSave} />
+  )
+  const button = screen.getByText('Set Folder')
+  await act(async () => { fireEvent.click(button) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 15)) })
+  expect(onPick).toHaveBeenCalled()
+  expect(window.electronAPI.checkPath).not.toHaveBeenCalled()
+  expect(onSave).toHaveBeenCalledWith('/tmp/games')
+})
+
+test('onPick returning null does nothing', async () => {
+  const onSave = vi.fn()
+  const onPick = vi.fn(async () => null)
+  const { container } = await renderSettled(
+    <EditablePathField value="/tmp/old" mode="directory" pickerLabel="Set Folder" onPick={onPick} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  await act(async () => { fireEvent.click(screen.getByText('Set Folder')) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 15)) })
+  expect(onSave).not.toHaveBeenCalled()
+  expect(input.value).toBe('/tmp/old')
+})
+
+test('validating flag blocks second commit (Enter then blur)', async () => {
+  let resolveCheck
+  const slowCheck = vi.fn(() => new Promise((res) => { resolveCheck = res }))
+  window.electronAPI.checkPath = slowCheck
+  const onSave = vi.fn()
+  const { container } = await renderSettled(
+    <EditablePathField value="/tmp/old" mode="directory" onPick={async () => null} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  await act(async () => { fireEvent.focus(input) })
+  await act(async () => { fireEvent.change(input, { target: { value: '/tmp/games' } }) })
+  await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+  await act(async () => { fireEvent.blur(input) })
+  expect(slowCheck).toHaveBeenCalledTimes(1)
+  await act(async () => { resolveCheck({ exists: true, isDirectory: true, isFile: false }) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 15)) })
+  expect(onSave).toHaveBeenCalledTimes(1)
+})
+
+test('trims whitespace and strips surrounding quotes before validation', async () => {
+  const onSave = vi.fn()
+  const { container } = await renderSettled(
+    <EditablePathField value="/tmp/old" mode="directory" onPick={async () => null} onSave={onSave} />
+  )
+  const input = container.querySelector('input')
+  await act(async () => { fireEvent.focus(input) })
+  await act(async () => { fireEvent.change(input, { target: { value: '  "/tmp/games"  ' } }) })
+  await act(async () => { fireEvent.keyDown(input, { key: 'Enter' }) })
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)) })
+  expect(window.electronAPI.checkPath).toHaveBeenCalledWith('/tmp/games')
+  expect(onSave).toHaveBeenCalledWith('/tmp/games')
+})


### PR DESCRIPTION
## What this changes

Four fields that were previously read-only with a browse button are now click-to-edit. You can type or paste a path directly into the field:

* Importer → Game Path
* Settings → Library → Default Game Folder / Downloads Folder
* Settings → Emulator → Program Path

When the input is submitted with `Enter` or loses focus, the typed path is checked against the filesystem:

* Valid paths are saved and the field flashes green.
* Invalid paths turn red, keep the typed text, and are never saved.
* Pressing `Escape` reverts the field to its saved value.
* The browse button remains available as a fallback.

The 7-Zip and Library Root fields are intentionally unchanged.

## Why
#132 

These fields previously only had a **Set Folder** or **Browse** button, so every change required opening a native dialog—even when the path was already known, such as `I:\XLibrary\RPGM`.

The renderer has no filesystem access, and there was no IPC handler for validating paths, so direct text entry was not possible. This change adds a small `check-path` handler that the renderer can call to validate a typed path before saving it.

## How it was tested

* [x] Added tests covering this change.
* [x] `npm run check` passes locally.
* [x] `CHANGELOG.md` updated.
* [x] Added a comment explaining the new IPC handler.
* [x] Targets `nightly`, not `main`.

## AI assistance

- [ ] No AI was used on this change
- [x] AI was used on this change

**Tool and model:** VSCode auto free

**What it wrote:**

* `check-path` IPC handler in `electron/ipc/windows.js:356`
* Preload binding `checkPath` in `electron/preload.js:71`
* New `src/components/ui/EditablePathField.jsx`
* Wiring into `Library.jsx:205/222` and `EmulatorLauncher.jsx:191`
* `pickScanFolder` and `SettingsStep.jsx:66`
* Tests

**What you verified yourself:**

* Verified that the tests pass.
* Manually tested the use cases.
* Re-tweaked the effects and values.

## IPC changes

* `check-path` — The main process calls `stat` on a path and returns `{ exists, isDirectory, isFile }`. For empty, relative, or non-existent paths, it returns `exists: false`.
* The renderer uses this handler to validate typed paths before saving them.
* The handler is exposed as `window.electronAPI.checkPath`.

## Anything the reviewer should know

* The picker button bypasses `check-path` because a native dialog already guarantees a valid absolute path. This also avoids error flicker on slow drives.
* A `validating` flag prevents `Enter` and `blur` from committing the same edit twice.
* Quote stripping and trimming are intentionally simple: `"C:/Games"` becomes `C:/Games`. Mismatched quotes such as `'a"` are also stripped, which is considered rare.
* `path.isAbsolute` is host-dependent. For example, typing `C:\` on Linux correctly fails.