### PR TITLE
Remove restart requirement on console interface config & Turn off auto-console in dev mode (use interface config instead)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ### Changed
+- (Dev-Only) DevTools no longer auto-opens in dev mode unless explicitly enabled in config.
+- Removed the stale restart popup and hint on the Show debug console toggle — it applies immediately to all open windows.
 - Allow setting folder and program locations by typing or paste a path directly besides using Browse / Select Folder button. 
   - Affected locations:  Atlas Importer, Library path settings,and Emulators. The 7z field path is not touched as it have more requirements than the based one.
   - Path resolution highlighting: red if invalid, green if path exists or pass the check.

--- a/electron/ipc/settings.js
+++ b/electron/ipc/settings.js
@@ -259,11 +259,15 @@ module.exports = function registerSettingsHandlers(ctx) {
         BrowserWindow.getAllWindows().forEach((win) => {
           if (win.isDestroyed()) return
           if (nextShowDebugConsole) {
-            if (!win.webContents.isDevToolsOpened()) win.webContents.openDevTools()
+            // Open in place without stealing focus from Settings.
+            if (!win.webContents.isDevToolsOpened()) win.webContents.openDevTools({ activate: false })
           } else if (win.webContents.isDevToolsOpened()) {
             win.webContents.closeDevTools()
           }
         })
+        // Not every Electron version honors activate: false, so keep Settings on top.
+        const senderWin = BrowserWindow.fromWebContents(event.sender)
+        if (senderWin && !senderWin.isDestroyed()) senderWin.focus()
       }
 
       const previousUpdateBranch = ctx.getConfiguredAppUpdateBranch?.({ Interface: previousInterface })

--- a/electron/main.js
+++ b/electron/main.js
@@ -1421,7 +1421,7 @@ function createWindow() {
   } else {
     mainWindow.loadFile(path.join(__dirname, '../dist/renderer/index.html'))
   }
-  if (process.defaultApp || appConfig?.Interface?.showDebugConsole) {
+  if (appConfig?.Interface?.showDebugConsole) {
     mainWindow.webContents.openDevTools()
   }
   mainWindow.on('maximize', () => mainWindow.webContents.send('window-state-changed', 'maximized'))
@@ -1470,7 +1470,7 @@ function createSettingsWindow(options = {}) {
   } else {
     settingsWindow.loadFile(path.join(__dirname, '../dist/renderer/settings.html'), tourQuery ? { search: tourQuery } : undefined)
   }
-  if (process.defaultApp || appConfig?.Interface?.showDebugConsole) {
+  if (appConfig?.Interface?.showDebugConsole) {
     settingsWindow.webContents.openDevTools()
   }
   settingsWindow.on('maximize', () => settingsWindow.webContents.send('window-state-changed', 'maximized'))
@@ -1522,7 +1522,7 @@ function createThemeBuilderWindow() {
   } else {
     themeBuilderWindow.loadFile(path.join(__dirname, '../dist/renderer/themebuilder.html'))
   }
-  if (process.defaultApp || appConfig?.Interface?.showDebugConsole) {
+  if (appConfig?.Interface?.showDebugConsole) {
     themeBuilderWindow.webContents.openDevTools()
   }
   themeBuilderWindow.on('maximize', () => themeBuilderWindow.webContents.send('window-state-changed', 'maximized'))
@@ -1596,7 +1596,7 @@ function createBannerEditorWindow() {
   } else {
     bannerEditorWindow.loadFile(path.join(__dirname, '../dist/renderer/bannereditor.html'))
   }
-  if (process.defaultApp || appConfig?.Interface?.showDebugConsole) {
+  if (appConfig?.Interface?.showDebugConsole) {
     bannerEditorWindow.webContents.openDevTools()
   }
   bannerEditorWindow.on('maximize', () => bannerEditorWindow.webContents.send('window-state-changed', 'maximized'))
@@ -1680,7 +1680,7 @@ function createImporterWindow(source = 'atlas') {
   ).then(() => {
     console.log('importer.html loaded successfully')
     sendImporterSource(importerSource)
-    if (process.defaultApp || appConfig?.Interface?.showDebugConsole) {
+    if (appConfig?.Interface?.showDebugConsole) {
       importerWindow.webContents.openDevTools()
     }
   }).catch((err) => {
@@ -1722,7 +1722,7 @@ function createGameDetailsWindow(recordId) {
   } else {
     win.loadFile(path.join(__dirname, '../dist/renderer/gamedetails.html'))
   }
-  if (process.defaultApp || appConfig?.Interface?.showDebugConsole) {
+  if (appConfig?.Interface?.showDebugConsole) {
     win.webContents.openDevTools()
   }
   win.on('maximize', () => win.webContents.send('window-state-changed', 'maximized'))

--- a/src/components/settings/Interface.jsx
+++ b/src/components/settings/Interface.jsx
@@ -289,7 +289,7 @@ const Interface = () => {
         override this for a single query.
       </p>
       <div className="border-t border-text opacity-25 my-2"></div>
-      {/* No restart needed: save-settings opens/closes DevTools on all open windows live. */}
+      {/* Applies live, no restart needed. */}
       <div className="flex items-center mb-2">
         <label className="flex-1">Show debug console window</label>
         <input

--- a/src/components/settings/Interface.jsx
+++ b/src/components/settings/Interface.jsx
@@ -132,7 +132,6 @@ const Interface = () => {
   const handleDebugConsoleChange = () => {
     setShowDebugConsole(!showDebugConsole);
     saveSettings({ showDebugConsole: !showDebugConsole });
-    alert("Changing the debug console setting requires a restart.");
   };
 
   const handleStartupUpdateCheckChange = () => {
@@ -290,6 +289,7 @@ const Interface = () => {
         override this for a single query.
       </p>
       <div className="border-t border-text opacity-25 my-2"></div>
+      {/* No restart needed: save-settings opens/closes DevTools on all open windows live. */}
       <div className="flex items-center mb-2">
         <label className="flex-1">Show debug console window</label>
         <input
@@ -299,9 +299,6 @@ const Interface = () => {
           onChange={handleDebugConsoleChange}
         />
       </div>
-      <p className="text-xs opacity-50 mb-2">
-        Enabling or Disabling the debug console will require a restart
-      </p>
       <div className="border-t border-text opacity-25 my-2"></div>
       <div className="flex items-center mb-2">
         <label className="flex-1">Enable adult (18+) content in Browse mode</label>

--- a/tests/debug-console-focus.test.js
+++ b/tests/debug-console-focus.test.js
@@ -1,0 +1,16 @@
+import { describe, test, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'electron', 'ipc', 'settings.js'), 'utf8')
+
+// The live toggle must not pull other windows in front of Settings.
+describe('Debug console toggle keeps Settings on top', () => {
+  test('live-toggle opens DevTools without activating', () => {
+    expect(src).toMatch(/openDevTools\(\{\s*activate:\s*false\s*\}\)/)
+  })
+
+  test('sender window is refocused after the toggle', () => {
+    expect(src).toMatch(/BrowserWindow\.fromWebContents\(event\.sender\)/)
+  })
+})

--- a/tests/devtools-gating.test.js
+++ b/tests/devtools-gating.test.js
@@ -1,0 +1,26 @@
+import { describe, test, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'electron', 'main.js'), 'utf8')
+
+// DevTools previously opened automatically when running under `process.defaultApp`
+// (electron . / npm start). The `Interface.showDebugConsole` setting already
+// exists for this — it should be the sole gate.
+describe('DevTools gating (Dev-Only)', () => {
+  test('no DevTools open is gated by process.defaultApp', () => {
+    expect(src).not.toMatch(/process\.defaultApp\s*\|\|\s*appConfig\?\.Interface\?\.showDebugConsole/)
+  })
+
+  test('every openDevTools call is gated only by showDebugConsole', () => {
+    const guards = [...src.matchAll(/if\s*\(appConfig\?\.Interface\?\.showDebugConsole\)\s*\{\s*\n\s*.*openDevTools\(\)/g)]
+    // createWindow, createSettingsWindow, createThemeBuilderWindow,
+    // createBannerEditorWindow, createImporterWindow, createGameDetailsWindow
+    expect(guards.length).toBe(6)
+  })
+
+  test('openDevTools count has not been reduced', () => {
+    const count = (src.match(/\.openDevTools\(\)/g) || []).length
+    expect(count).toBe(6)
+  })
+})

--- a/tests/devtools-gating.test.js
+++ b/tests/devtools-gating.test.js
@@ -4,9 +4,7 @@ import path from 'path'
 
 const src = fs.readFileSync(path.join(__dirname, '..', 'electron', 'main.js'), 'utf8')
 
-// DevTools previously opened automatically when running under `process.defaultApp`
-// (electron . / npm start). The `Interface.showDebugConsole` setting already
-// exists for this — it should be the sole gate.
+// showDebugConsole is the sole gate for DevTools (no auto-open in dev mode).
 describe('DevTools gating (Dev-Only)', () => {
   test('no DevTools open is gated by process.defaultApp', () => {
     expect(src).not.toMatch(/process\.defaultApp\s*\|\|\s*appConfig\?\.Interface\?\.showDebugConsole/)
@@ -14,8 +12,7 @@ describe('DevTools gating (Dev-Only)', () => {
 
   test('every openDevTools call is gated only by showDebugConsole', () => {
     const guards = [...src.matchAll(/if\s*\(appConfig\?\.Interface\?\.showDebugConsole\)\s*\{\s*\n\s*.*openDevTools\(\)/g)]
-    // createWindow, createSettingsWindow, createThemeBuilderWindow,
-    // createBannerEditorWindow, createImporterWindow, createGameDetailsWindow
+    // main, settings, theme builder, banner editor, importer, game details
     expect(guards.length).toBe(6)
   })
 

--- a/tests/interface-debug-console.test.js
+++ b/tests/interface-debug-console.test.js
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+const src = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'components', 'settings', 'Interface.jsx'),
+  'utf8',
+)
+
+// The debug-console toggle applies live via save-settings (main opens/closes
+// DevTools on all open windows), so it must not show a restart popup or hint.
+describe('Interface debug console (no restart)', () => {
+  test('toggling never pops a restart alert', () => {
+    expect(src).not.toMatch(/debug console setting requires a restart/i)
+  })
+
+  test('no restart hint remains next to the toggle', () => {
+    expect(src).not.toMatch(/debug console will require a restart/i)
+  })
+
+  test('toggle still saves the setting (guard against over-deletion)', () => {
+    expect(src).toMatch(/saveSettings\(\{\s*showDebugConsole:/)
+  })
+
+  test('language restart note is untouched', () => {
+    expect(src).toMatch(/system language will require a restart/i)
+  })
+})

--- a/tests/interface-debug-console.test.js
+++ b/tests/interface-debug-console.test.js
@@ -7,8 +7,7 @@ const src = fs.readFileSync(
   'utf8',
 )
 
-// The debug-console toggle applies live via save-settings (main opens/closes
-// DevTools on all open windows), so it must not show a restart popup or hint.
+// The toggle applies live, so no restart popup or hint.
 describe('Interface debug console (no restart)', () => {
   test('toggling never pops a restart alert', () => {
     expect(src).not.toMatch(/debug console setting requires a restart/i)


### PR DESCRIPTION
## What this changes
- Remove auto dev console opening on dev mode. (Dev-Only)
- Remove alert pop up and helper text that says client needs to be restarted. The change is now instant.

## Why
- We already have a config for dev console, this shouldn't be an auto open for dev.
- Additionally, some performance settings seem to work better without dev console opened (e.g. search performance, filter test), so turn it off by default will help showing more accurate performance testing when we have too many log.

## How it was tested

- [X] Added tests that cover this change
- [x] For a fix: the regression test fails against the unfixed code
- [x] `npm run check` passes locally
- [x] New functions and IPC handlers have comments explaining *why*
- [x] `CHANGELOG.md` updated
- [X] This PR targets `nightly`, not `main`

## AI assistance

- [x] No AI was used on this change
- [ ] AI was used on this change
