### PR TITLE
[no-test-needed] dependabot: update dependencies - 09082026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Changed
+- Patched dependencies for sharp from 0.34.5 -> 0.35.0.
 - Allow setting folder and program locations by typing or paste a path directly besides using Browse / Select Folder button. 
   - Affected locations:  Atlas Importer, Library path settings,and Emulators. The 7z field path is not touched as it have more requirements than the based one.
   - Path resolution highlighting: red if invalid, green if path exists or pass the check.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atlas",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atlas",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@vitest/coverage-v8": "^4.1.10",
@@ -21,7 +21,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-virtualized": "^9.22.6",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.0",
         "sqlite3": "^6.0.1"
       },
       "devDependencies": {
@@ -115,7 +115,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -469,7 +468,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -493,7 +491,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -783,6 +780,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -804,6 +802,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1646,9 +1645,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -1658,19 +1657,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -1680,19 +1679,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -1706,9 +1724,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -1722,11 +1740,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1738,11 +1759,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1754,11 +1778,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1770,11 +1797,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1786,11 +1816,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1802,11 +1835,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1818,11 +1854,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1834,11 +1873,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1850,33 +1892,39 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1884,87 +1932,99 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1972,43 +2032,49 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2016,38 +2082,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -2057,16 +2139,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -2076,16 +2158,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -2095,7 +2177,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -2683,7 +2765,6 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-cmcd/-/cml-cmcd-2.3.2.tgz",
       "integrity": "sha512-SKBBjLmci0WK8HMjuv+36tVIMktonoOoxsXblOFZmB+ePPV2zjRMTD+2ZmE/1VEPJkKHENyhSjSHgJyeOlvZ1A==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -2786,7 +2867,6 @@
       "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.1.4.tgz",
       "integrity": "sha512-jbixqjiJIc16SGxylHwiOzO+DuhkGfuP+fJ9AHeVJKdFDKnabgfCDpnp6dvZpZnjMj4nHvzVtuUV7RISPIwYXw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -2813,7 +2893,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3040,7 +3119,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
       "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.10",
@@ -3204,7 +3282,6 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3786,7 +3863,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -4243,7 +4319,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -4552,7 +4629,6 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -4797,6 +4873,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -4817,6 +4894,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -4832,6 +4910,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4842,6 +4921,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -5024,7 +5104,6 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6854,6 +6933,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7436,7 +7516,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -7587,6 +7666,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -7604,6 +7684,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -7893,7 +7974,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7903,7 +7983,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8119,6 +8198,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -8331,47 +8411,52 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/sharp/node_modules/semver": {
@@ -8834,6 +8919,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -8955,7 +9041,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9239,7 +9324,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -9331,7 +9415,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9344,7 +9427,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -9716,7 +9798,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3251,9 +3251,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3746,9 +3746,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3844,9 +3844,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -3864,11 +3864,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4034,9 +4034,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001800",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -4832,9 +4832,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.383",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.383.tgz",
-      "integrity": "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==",
+      "version": "1.5.425",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.425.tgz",
+      "integrity": "sha512-QvPtl41EUOnuT1HBvMKgxXRIaHNcagBPs50u7VULzhZXaGfqTbZyE16LQsctZ/RQHlGu+FOWeDTR4mY6YbeF1g==",
       "dev": true,
       "license": "ISC"
     },
@@ -5412,9 +5412,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -6415,9 +6415,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.2.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
-      "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.8.tgz",
+      "integrity": "sha512-G2TX62h58ZHuwqetJgP2F4ualakqAmZtBYe3jWen7gxQRw5xApX6crnFtuB91WC0c3ESBnva+kGSnb3+6pIQDQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6966,9 +6966,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -7146,9 +7146,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9266,9 +9266,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-virtualized": "^9.22.6",
-        "sharp": "^0.35.0",
+        "sharp": "^0.35.4",
         "sqlite3": "^6.0.1"
       },
       "devDependencies": {
@@ -6440,9 +6440,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-virtualized": "^9.22.6",
-    "sharp": "^0.34.5",
+    "sharp": "^0.35.0",
     "sqlite3": "^6.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -91,9 +91,9 @@
     "pretest:run": "npm run build:extension:icons",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "build": "npm run build:extension:icons && vite build && electron-builder --win --x64",
+    "build": "npm run build:extension:icons && vite build && node scripts/build-patched.js",
     "preview": "vite preview",
-    "publish": "npm run build:extension:icons && vite build && electron-builder --win --x64 -p always",
+    "publish": "npm run build:extension:icons && vite build && node scripts/build-patched.js --publish",
     "build:extension": "node scripts/package-extension.js",
     "build:extension:icons": "node scripts/generate-extension-icons.js",
     "format": "prettier --write \"src/**/*.{js,jsx,css}\" \"electron/**/*.{js,jsx}\"",
@@ -107,9 +107,10 @@
     },
     "publish": {
       "provider": "github",
-      "owner": "towerwatchman",
-      "repo": "Atlas",
-      "releaseType": "release",
+      "owner": "codeon89",
+      "repo": "Atlas-Patched",
+      "releaseType": "draft",
+      "channel": "patched",
       "vPrefixedTagName": true
     },
     "files": [
@@ -184,7 +185,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-virtualized": "^9.22.6",
-    "sharp": "^0.35.0",
+    "sharp": "^0.35.4",
     "sqlite3": "^6.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## What this changes

Bumps the npm_and_yarn group with updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [sharp](https://github.com/lovell/sharp) | `0.34.5` | `0.35.4` |
| [@xmldom/xmldom](https://github.com/xmldom/xmldom) | `0.8.13` | `0.8.15` |
| [browserslist](https://github.com/browserslist/browserslist) | `4.28.4` | `4.28.9` |
| [fast-uri](https://github.com/fastify/fast-uri) | `3.1.5` | `3.1.7` |
| [joi](https://github.com/hapijs/joi) | `18.2.3` | `18.2.8` |
| [nanoid](https://github.com/ai/nanoid) | `3.3.17` | `3.3.18` |
| [js-yaml](https://github.com/nodeca/js-yaml) | `4.3.1` | `4.3.2` |

## Why

Updates `sharp` from 0.34.5 to 0.35.0

<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/lovell/sharp/releases">sharp's releases</a>.</em></p>
<blockquote>
<h2>v0.35.0</h2>
<ul>
<li>
<p>Breaking: Drop support for Node.js 18, now requires Node.js &gt;= 20.9.0.</p>
</li>
<li>
<p>Breaking: Remove <code>install</code> script from <code>package.json</code> file.
Compiling from source is now opt-in via the <code>build</code> script.</p>
</li>
<li>
<p>Breaking: Lossy AVIF output is now tuned using SSIMULACRA2-based <code>iq</code> quality metrics.</p>
</li>
<li>
<p>Breaking: Add <code>limitInputChannels</code> with a default value of 5.</p>
</li>
<li>
<p>Breaking: Remove deprecated <code>failOnError</code> constructor property.</p>
</li>
<li>
<p>Breaking: Remove deprecated <code>paletteBitDepth</code> from <code>metadata</code> response.</p>
</li>
<li>
<p>Breaking: Remove deprecated properties from <code>sharpen</code> operation.</p>
</li>
<li>
<p>Breaking: Rename <code>format.jp2k</code> as <code>format.jp2</code> for API consistency.</p>
</li>
<li>
<p>Upgrade to libvips v8.18.3 for upstream bug fixes.</p>
</li>
<li>
<p>Remove experimental status from WebAssembly binaries.</p>
</li>
<li>
<p>Add prebuilt binaries for FreeBSD (WebAssembly).</p>
</li>
<li>
<p>Deprecate Windows 32-bit (win32-ia32) prebuilt binaries.</p>
</li>
<li>
<p>Ensure TIFF output <code>bitdepth</code> option is limited to 1, 2 or 4.</p>
</li>
<li>
<p>Add AVIF/HEIF <code>tune</code> option for control over quality metrics.
<a href="https://redirect.github.com/lovell/sharp/issues/4227">#4227</a></p>
</li>
<li>
<p>Add <code>keepGainMap</code> and <code>withGainMap</code> to process HDR JPEG images with embedded gain maps.
<a href="https://redirect.github.com/lovell/sharp/issues/4314">#4314</a></p>
</li>
<li>
<p>Add <code>toUint8Array</code> for output image as a <code>TypedArray</code> backed by a transferable <code>ArrayBuffer</code>.
<a href="https://redirect.github.com/lovell/sharp/issues/4355">#4355</a></p>
</li>
<li>
<p>Require prebuilt binaries using static paths to aid code bundling.
<a href="https://redirect.github.com/lovell/sharp/issues/4380">#4380</a></p>
</li>
<li>
<p>TypeScript: Ensure <code>FormatEnum</code> keys match reality.
<a href="https://redirect.github.com/lovell/sharp/issues/4475">#4475</a></p>
</li>
<li>
<p>Add <code>margin</code> option to <code>trim</code> operation.
<a href="https://redirect.github.com/lovell/sharp/issues/4480">#4480</a>
<a href="https://github.com/eddienubes"><code>@​eddienubes</code></a></p>
</li>
<li>
<p>Ensure HEIF primary item is used as default page/frame.
<a href="https://redirect.github.com/lovell/sharp/issues/4487">#4487</a></p>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/lovell/sharp/commit/2ed5af48cdf4c7a1c93fc82ff37d64e151bbadb7"><code>2ed5af4</code></a> Release v0.35.0</li>
<li><a href="https://github.com/lovell/sharp/commit/4475cf10e7cf893d366f4e0d12fe1deae56d7398"><code>4475cf1</code></a> Tests: update locator hash for sharp-libvips v1.3.0</li>
<li><a href="https://github.com/lovell/sharp/commit/deb22ddd2fa6a9593bb720ba51e05b8b905504a2"><code>deb22dd</code></a> Upgrade to sharp-libvips v1.3.0</li>
<li><a href="https://github.com/lovell/sharp/commit/07f1be984a2d221d0880f8b2cba6f298caf5370b"><code>07f1be9</code></a> Prerelease v0.35.0-rc.8</li>
<li><a href="https://github.com/lovell/sharp/commit/df1109bf3af863ffbb6c3cfd636fc24723aea64d"><code>df1109b</code></a> Prerelease v0.35.0-rc.7</li>
<li><a href="https://github.com/lovell/sharp/commit/aca49b37152964138a150b8307532708fc0e4a3c"><code>aca49b3</code></a> Upgrade to libvips v8.18.3</li>
<li><a href="https://github.com/lovell/sharp/commit/e9e86f5802a814549ce9007dfa183ad80aa04189"><code>e9e86f5</code></a> Type-check density option before range validation (<a href="https://redirect.github.com/lovell/sharp/issues/4536">#4536</a>)</li>
<li><a href="https://github.com/lovell/sharp/commit/2f0bcf00ed1ec9b3b60fd184ec6c512ba7e3233c"><code>2f0bcf0</code></a> Docs: update supported image formats</li>
<li><a href="https://github.com/lovell/sharp/commit/98e03b83fbc07bd7bb2e421bc2906d4e62d84c7f"><code>98e03b8</code></a> Revert &quot;Guard heif bitdepth property for prebuilt binaries&quot;</li>
<li><a href="https://github.com/lovell/sharp/commit/e4ea2f35eb7194ec7ade46de64bf2a9904c07127"><code>e4ea2f3</code></a> CI: Ignore package minimum age in smoke tests</li>
<li>Additional commits viewable in <a href="https://github.com/lovell/sharp/compare/v0.34.5...v0.35.0">compare view</a></li>
</ul>
</details>
<br />

Updates `sharp` from 0.35.0 to 0.35.4
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/lovell/sharp/releases">sharp's releases</a>.</em></p>
<blockquote>
<h2>v0.35.4</h2>
<p><a href="https://github.com/lovell/sharp-libvips/releases/tag/v1.3.3">https://github.com/lovell/sharp-libvips/releases/tag/v1.3.3</a></p>
<ul>
<li>
<p>Bound resize dimensions to coordinate limit.</p>
</li>
<li>
<p>Bound composite left and top to coordinate limit.
<a href="https://redirect.github.com/lovell/sharp/pull/4564">#4564</a>
<a href="https://github.com/metsw24-max"><code>@​metsw24-max</code></a></p>
</li>
<li>
<p>Round palette bit depth up for png and gif colours.
<a href="https://redirect.github.com/lovell/sharp/pull/4569">#4569</a>
<a href="https://github.com/metsw24-max"><code>@​metsw24-max</code></a></p>
</li>
<li>
<p>Ensure tiff.subifd input option is used.
<a href="https://redirect.github.com/lovell/sharp/pull/4572">#4572</a>
<a href="https://github.com/metsw24-max"><code>@​metsw24-max</code></a></p>
</li>
<li>
<p>Ensure <code>info.pages</code> is correct when limiting input page range.
<a href="https://redirect.github.com/lovell/sharp/pull/4578">#4578</a>
<a href="https://github.com/metsw24-max"><code>@​metsw24-max</code></a></p>
</li>
<li>
<p>Improve support for input Streams finishing before output is requested.
<a href="https://redirect.github.com/lovell/sharp/pull/4584">#4584</a>
<a href="https://github.com/Jaybhade"><code>@​Jaybhade</code></a></p>
</li>
</ul>
<h2>v0.35.4-rc.0</h2>
<ul>
<li>
<p>Upgrade to libvips v8.18.6 for upstream bug fixes.</p>
</li>
<li>
<p>Bound resize dimensions to coordinate limit.</p>
</li>
<li>
<p>Bound composite left and top to coordinate limit.
<a href="https://redirect.github.com/lovell/sharp/pull/4564">#4564</a>
<a href="https://github.com/metsw24-max"><code>@​metsw24-max</code></a></p>
</li>
<li>
<p>Round palette bit depth up for png and gif colours.
<a href="https://redirect.github.com/lovell/sharp/pull/4569">#4569</a>
<a href="https://github.com/metsw24-max"><code>@​metsw24-max</code></a></p>
</li>
<li>
<p>Ensure tiff.subifd input option is used.
<a href="https://redirect.github.com/lovell/sharp/pull/4572">#4572</a>
<a href="https://github.com/metsw24-max"><code>@​metsw24-max</code></a></p>
</li>
<li>
<p>Ensure <code>info.pages</code> is correct when limiting input page range.
<a href="https://redirect.github.com/lovell/sharp/pull/4578">#4578</a>
<a href="https://github.com/metsw24-max"><code>@​metsw24-max</code></a></p>
</li>
<li>
<p>Improve support for input Streams finishing before output is requested.
<a href="https://redirect.github.com/lovell/sharp/pull/4584">#4584</a>
<a href="https://github.com/Jaybhade"><code>@​Jaybhade</code></a></p>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/lovell/sharp/commit/7f1a0a22cc285fe180766f4935d50b55af6e8432"><code>7f1a0a2</code></a> Release v0.35.4</li>
<li><a href="https://github.com/lovell/sharp/commit/f927818924bc5a9493d822a4e8b23ec5857c52e1"><code>f927818</code></a> Upgrade to sharp-libvips v1.3.3</li>
<li><a href="https://github.com/lovell/sharp/commit/e80209240d005c71e1173a50dd9cd4db4ce2a9e6"><code>e802092</code></a> Prerelease v0.35.4-rc.0</li>
<li><a href="https://github.com/lovell/sharp/commit/e13eb2f97a0a22f1ef726e8d0cd33f7c56835945"><code>e13eb2f</code></a> CI: Fix wasm32 build (<a href="https://redirect.github.com/lovell/sharp/issues/4589">#4589</a>)</li>
<li><a href="https://github.com/lovell/sharp/commit/a82a0b3d58bc25854ad1e925e6eb0a50725d1489"><code>a82a0b3</code></a> Upgrade to libvips v8.18.6</li>
<li><a href="https://github.com/lovell/sharp/commit/8044fe43e36d0ea7f8beb89f79a37bb0f3342e84"><code>8044fe4</code></a> Bound resize dimensions to coordinate limit</li>
<li><a href="https://github.com/lovell/sharp/commit/147f8591a153bc4a1e199c3fe3150fac2931b30c"><code>147f859</code></a> Docs: changelog entries for <a href="https://redirect.github.com/lovell/sharp/issues/4578">#4578</a> <a href="https://redirect.github.com/lovell/sharp/issues/4584">#4584</a></li>
<li><a href="https://github.com/lovell/sharp/commit/ee5bfb853de75a611c64381783b04032a3a897d8"><code>ee5bfb8</code></a> Tests: use yauzl directly rather than via extract-zip wrapper</li>
<li><a href="https://github.com/lovell/sharp/commit/7a7788928f8a2a429f45039010a87cee35401694"><code>7a77889</code></a> Bump uraimo/run-on-arch-action from 3.1.0 to 3.2.0 (<a href="https://redirect.github.com/lovell/sharp/issues/4588">#4588</a>)</li>
<li><a href="https://github.com/lovell/sharp/commit/ea5bef24c187b2c7ee3fe3cad3b45c8cb67a46fd"><code>ea5bef2</code></a> Improve support for input Streams finishing before output is requested (<a href="https://redirect.github.com/lovell/sharp/issues/4584">#4584</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/lovell/sharp/compare/v0.35.0...v0.35.4">compare view</a></li>
</ul>
</details>
<br />


Updates `@xmldom/xmldom` from 0.8.13 to 0.8.15
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/xmldom/xmldom/releases">@​xmldom/xmldom's releases</a>.</em></p>
<blockquote>
<h2>0.8.15</h2>
<p><a href="https://github.com/xmldom/xmldom/compare/0.8.14...0.8.15">Commits</a></p>
<h3>Fixed</h3>
<ul>
<li>Security: parsing a deeply or repeatedly namespaced document no longer consumes quadratic memory; the in-scope namespace map is inherited through the prototype chain instead of being copied for every prefix-declaring element (O(N) instead of O(N²)), preventing a denial-of-service reachable from <code>DOMParser.parseFromString</code> with default options. Serialized output is byte-identical. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-965w-775f-mr7g"><code>GHSA-965w-775f-mr7g</code></a></li>
<li>Security: attribute de-duplication during parsing is now O(M) instead of O(M²); the <code>NamedNodeMap</code> parse-time dedup path uses a null-prototype membership index, so a well-formed document with a hostile number of duplicate attributes can no longer wedge the parse. Attribute order and duplicate resolution (last value wins, first position kept) are byte-identical, preserving the XML <a href="https://www.w3.org/TR/xml/#uniqattspec">no-duplicate-attributes well-formedness constraint</a>. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-8344-3jmq-59r6"><code>GHSA-8344-3jmq-59r6</code></a></li>
<li>Security: trimming trailing whitespace from an XML end tag (<a href="https://www.w3.org/TR/xml/#NT-ETag"><code>ETag</code></a>) is now anchored so it runs in linear time instead of backtracking quadratically on a long whitespace run, preventing a ReDoS reachable from <code>DOMParser.parseFromString</code>. Trimmed output is byte-identical. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-x4fp-j954-r2f4"><code>GHSA-x4fp-j954-r2f4</code></a></li>
<li>Security: malformed-input recovery is now linear instead of quadratic — the malformed tag-name scan terminates at an embedded <code>&lt;</code>, and <code>Node.prototype.normalize()</code> merges adjacent text nodes in O(K) instead of O(K²) (also reachable programmatically), per <a href="https://dom.spec.whatwg.org/#dom-node-normalize"><code>normalize()</code></a> in the WHATWG DOM spec. DOM output is unchanged; only the reported error text differs. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-93r5-fhx6-vmg9"><code>GHSA-93r5-fhx6-vmg9</code></a></li>
<li>Security: <code>XMLSerializer.serializeToString()</code> under <code>{ requireWellFormed: true }</code> now rejects a DocType <code>name</code> that is not a valid XML <a href="https://www.w3.org/TR/xml/#NT-Name"><code>Name</code></a>, throwing <code>InvalidStateError</code> — matching the sibling <code>publicId</code>/<code>systemId</code>/<code>internalSubset</code> checks and preventing XML injection via <code>DocumentType.name</code>. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-27p8-2357-5qqv"><code>GHSA-27p8-2357-5qqv</code></a></li>
<li>Security: <code>XMLSerializer.serializeToString()</code> under <code>{ requireWellFormed: true }</code> now validates a processing-instruction target as an XML <a href="https://www.w3.org/TR/xml-names/#NT-NCName"><code>NCName</code></a> and rejects a case-insensitive <code>xml</code>, throwing <code>InvalidStateError</code> — a check <code>0.8.x</code> did not previously perform, preventing PI-target injection via <code>&gt;</code>, <code>?</code>, or whitespace. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-c7q8-3ch8-vqpv"><code>GHSA-c7q8-3ch8-vqpv</code></a></li>
<li>Security: <code>Document.createEntityReference()</code> now rejects an invalid XML <a href="https://www.w3.org/TR/xml/#NT-Name"><code>Name</code></a> at creation, and <code>XMLSerializer.serializeToString()</code> under <code>{ requireWellFormed: true }</code> validates an <code>EntityReference</code> <code>nodeName</code> as an XML <code>Name</code>, throwing <code>InvalidStateError</code> — preventing XML injection via an entity-reference name. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-6gmq-8vp8-gcm6"><code>GHSA-6gmq-8vp8-gcm6</code></a></li>
<li>Security: the parser now reports a not-well-formed end tag whose valid name is followed by trailing content as a recoverable <code>error</code> instead of accepting it silently, per the XML <a href="https://www.w3.org/TR/xml/#NT-ETag"><code>ETag</code></a> production; parsing recovers to the byte-identical DOM. Consumers that want strict rejection can escalate the reported <code>error</code> to fatal via the parser's <code>errorHandler</code>. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-6h8r-xr42-gp59"><code>GHSA-6h8r-xr42-gp59</code></a></li>
</ul>
<p>Thank you,
<a href="https://github.com/ericchiang"><code>@​ericchiang</code></a>,
<a href="https://github.com/bhaswanthc"><code>@​bhaswanthc</code></a>,
<a href="https://github.com/arpitjain099"><code>@​arpitjain099</code></a>,
<a href="https://github.com/Paranoidgrinch"><code>@​Paranoidgrinch</code></a>,
for your contributions</p>
<h2>0.8.14</h2>
<p><a href="https://github.com/xmldom/xmldom/compare/0.8.13...0.8.14">Commits</a></p>
<h3>Fixed</h3>
<ul>
<li>Security: <code>XMLSerializer.serializeToString()</code> now also rejects invalid element and attribute names when <code>{ requireWellFormed: true }</code> is passed, throwing <code>InvalidStateError</code> for a name that is not a valid XML <a href="https://www.w3.org/TR/xml-names/#NT-QName"><code>QName</code></a> (this covers the namespace prefix, which surfaces in the element qualified name or in a synthesized <code>xmlns:</code> declaration). This prevents XML injection via <code>createElement()</code> / <code>setAttribute()</code>, extending the existing <code>requireWellFormed</code> checks to the serialized name set. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-w2rr-34g9-rvrj"><code>GHSA-w2rr-34g9-rvrj</code></a> <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-4w3w-2rp5-g8jm"><code>GHSA-4w3w-2rp5-g8jm</code></a></li>
</ul>
<p>Thank you,
<a href="https://github.com/bhaswanthc"><code>@​bhaswanthc</code></a>,
<a href="https://github.com/jmestwa-coder"><code>@​jmestwa-coder</code></a>,
for your contributions</p>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/xmldom/xmldom/blob/master/CHANGELOG.md">@​xmldom/xmldom's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/xmldom/xmldom/compare/0.8.14...0.8.15">0.8.15</a></h2>
<h3>Fixed</h3>
<ul>
<li>Security: parsing a deeply or repeatedly namespaced document no longer consumes quadratic memory; the in-scope namespace map is inherited through the prototype chain instead of being copied for every prefix-declaring element (O(N) instead of O(N²)), preventing a denial-of-service reachable from <code>DOMParser.parseFromString</code> with default options. Serialized output is byte-identical. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-965w-775f-mr7g"><code>GHSA-965w-775f-mr7g</code></a></li>
<li>Security: attribute de-duplication during parsing is now O(M) instead of O(M²); the <code>NamedNodeMap</code> parse-time dedup path uses a null-prototype membership index, so a well-formed document with a hostile number of duplicate attributes can no longer wedge the parse. Attribute order and duplicate resolution (last value wins, first position kept) are byte-identical, preserving the XML <a href="https://www.w3.org/TR/xml/#uniqattspec">no-duplicate-attributes well-formedness constraint</a>. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-8344-3jmq-59r6"><code>GHSA-8344-3jmq-59r6</code></a></li>
<li>Security: trimming trailing whitespace from an XML end tag (<a href="https://www.w3.org/TR/xml/#NT-ETag"><code>ETag</code></a>) is now anchored so it runs in linear time instead of backtracking quadratically on a long whitespace run, preventing a ReDoS reachable from <code>DOMParser.parseFromString</code>. Trimmed output is byte-identical. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-x4fp-j954-r2f4"><code>GHSA-x4fp-j954-r2f4</code></a></li>
<li>Security: malformed-input recovery is now linear instead of quadratic — the malformed tag-name scan terminates at an embedded <code>&lt;</code>, and <code>Node.prototype.normalize()</code> merges adjacent text nodes in O(K) instead of O(K²) (also reachable programmatically), per <a href="https://dom.spec.whatwg.org/#dom-node-normalize"><code>normalize()</code></a> in the WHATWG DOM spec. DOM output is unchanged; only the reported error text differs. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-93r5-fhx6-vmg9"><code>GHSA-93r5-fhx6-vmg9</code></a></li>
<li>Security: <code>XMLSerializer.serializeToString()</code> under <code>{ requireWellFormed: true }</code> now rejects a DocType <code>name</code> that is not a valid XML <a href="https://www.w3.org/TR/xml/#NT-Name"><code>Name</code></a>, throwing <code>InvalidStateError</code> — matching the sibling <code>publicId</code>/<code>systemId</code>/<code>internalSubset</code> checks and preventing XML injection via <code>DocumentType.name</code>. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-27p8-2357-5qqv"><code>GHSA-27p8-2357-5qqv</code></a></li>
<li>Security: <code>XMLSerializer.serializeToString()</code> under <code>{ requireWellFormed: true }</code> now validates a processing-instruction target as an XML <a href="https://www.w3.org/TR/xml-names/#NT-NCName"><code>NCName</code></a> and rejects a case-insensitive <code>xml</code>, throwing <code>InvalidStateError</code> — a check <code>0.8.x</code> did not previously perform, preventing PI-target injection via <code>&gt;</code>, <code>?</code>, or whitespace. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-c7q8-3ch8-vqpv"><code>GHSA-c7q8-3ch8-vqpv</code></a></li>
<li>Security: <code>Document.createEntityReference()</code> now rejects an invalid XML <a href="https://www.w3.org/TR/xml/#NT-Name"><code>Name</code></a> at creation, and <code>XMLSerializer.serializeToString()</code> under <code>{ requireWellFormed: true }</code> validates an <code>EntityReference</code> <code>nodeName</code> as an XML <code>Name</code>, throwing <code>InvalidStateError</code> — preventing XML injection via an entity-reference name. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-6gmq-8vp8-gcm6"><code>GHSA-6gmq-8vp8-gcm6</code></a></li>
<li>Security: the parser now reports a not-well-formed end tag whose valid name is followed by trailing content as a recoverable <code>error</code> instead of accepting it silently, per the XML <a href="https://www.w3.org/TR/xml/#NT-ETag"><code>ETag</code></a> production; parsing recovers to the byte-identical DOM. Consumers that want strict rejection can escalate the reported <code>error</code> to fatal via the parser's <code>errorHandler</code>. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-6h8r-xr42-gp59"><code>GHSA-6h8r-xr42-gp59</code></a></li>
</ul>
<p>Thank you,
<a href="https://github.com/ericchiang"><code>@​ericchiang</code></a>,
<a href="https://github.com/bhaswanthc"><code>@​bhaswanthc</code></a>,
<a href="https://github.com/arpitjain099"><code>@​arpitjain099</code></a>,
<a href="https://github.com/Paranoidgrinch"><code>@​Paranoidgrinch</code></a>,
for your contributions</p>
<h2><a href="https://github.com/xmldom/xmldom/compare/0.9.10...0.9.11">0.9.11</a></h2>
<h3>Fixed</h3>
<ul>
<li>Security: <code>XMLSerializer.serializeToString()</code> now also rejects invalid element and attribute names when <code>{ requireWellFormed: true }</code> is passed, throwing <code>InvalidStateError</code> for a name that is not a valid XML <a href="https://www.w3.org/TR/xml-names/#NT-QName"><code>QName</code></a> (this covers the namespace prefix, which surfaces in the element qualified name or in a synthesized <code>xmlns:</code> declaration). This prevents XML injection via <code>createElement()</code> / <code>setAttribute()</code>, extending the existing <code>requireWellFormed</code> checks to the serialized name set. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-w2rr-34g9-rvrj"><code>GHSA-w2rr-34g9-rvrj</code></a> <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-4w3w-2rp5-g8jm"><code>GHSA-4w3w-2rp5-g8jm</code></a></li>
<li>Security: the processing-instruction grammar regex no longer backtracks quadratically on an unterminated processing instruction (<code>&lt;?…</code> with no closing <code>?&gt;</code>), preventing a denial-of-service (ReDoS) reachable from <code>DOMParser.parseFromString</code> with default options. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-g53g-w8rj-fmg7"><code>GHSA-g53g-w8rj-fmg7</code></a></li>
<li><code>CharacterData</code> <code>nodeValue</code> and <code>data</code> are now kept in sync <a href="https://redirect.github.com/xmldom/xmldom/pull/990"><code>[#990](https://github.com/xmldom/xmldom/issues/990)</code></a></li>
</ul>
<h3>Chore</h3>
<ul>
<li>updated dependencies</li>
</ul>
<p>Thank you,
<a href="https://github.com/bhaswanthc"><code>@​bhaswanthc</code></a>,
<a href="https://github.com/jmestwa-coder"><code>@​jmestwa-coder</code></a>,
<a href="https://github.com/stevenobiajulu"><code>@​stevenobiajulu</code></a>,
for your contributions</p>
<h2><a href="https://github.com/xmldom/xmldom/compare/0.8.13...0.8.14">0.8.14</a></h2>
<h3>Fixed</h3>
<ul>
<li>Security: <code>XMLSerializer.serializeToString()</code> now also rejects invalid element and attribute names when <code>{ requireWellFormed: true }</code> is passed, throwing <code>InvalidStateError</code> for a name that is not a valid XML <a href="https://www.w3.org/TR/xml-names/#NT-QName"><code>QName</code></a> (this covers the namespace prefix, which surfaces in the element qualified name or in a synthesized <code>xmlns:</code> declaration). This prevents XML injection via <code>createElement()</code> / <code>setAttribute()</code>, extending the existing <code>requireWellFormed</code> checks to the serialized name set. <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-w2rr-34g9-rvrj"><code>GHSA-w2rr-34g9-rvrj</code></a> <a href="https://github.com/xmldom/xmldom/security/advisories/GHSA-4w3w-2rp5-g8jm"><code>GHSA-4w3w-2rp5-g8jm</code></a></li>
</ul>
<p>Thank you,
<a href="https://github.com/bhaswanthc"><code>@​bhaswanthc</code></a>,
<a href="https://github.com/jmestwa-coder"><code>@​jmestwa-coder</code></a>,
for your contributions</p>
<h2><a href="https://github.com/xmldom/xmldom/compare/0.9.9...0.9.10">0.9.10</a></h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/xmldom/xmldom/commit/b5b8fb5b579ae1183b34e74b3bc39d7eb50a226a"><code>b5b8fb5</code></a> 0.8.15</li>
<li><a href="https://github.com/xmldom/xmldom/commit/327508ea98d169285b2c0559836332a9879de213"><code>327508e</code></a> docs: add 0.8.15 CHANGELOG entry</li>
<li><a href="https://github.com/xmldom/xmldom/commit/f40ccb861eee0acbf5ee4feb9a34932e87b329c9"><code>f40ccb8</code></a> fix: prevent quadratic malformed-tag recovery and normalize() adjacent-text m...</li>
<li><a href="https://github.com/xmldom/xmldom/commit/3abb0934f5a8a84d83a1f9cde0f2bd04c08b2a09"><code>3abb093</code></a> fix: prevent end-tag whitespace-trim ReDoS via anchored trim (GHSA-x4fp-j954-...</li>
<li><a href="https://github.com/xmldom/xmldom/commit/2c548f200cfec991cd5846627ef8f03542309213"><code>2c548f2</code></a> fix: prevent quadratic attribute de-duplication via null-prototype membership...</li>
<li><a href="https://github.com/xmldom/xmldom/commit/08a74b47c7f29d2e9b3212682856b959040d1838"><code>08a74b4</code></a> test: characterize NamedNodeMap attribute de-duplication before the index ref...</li>
<li><a href="https://github.com/xmldom/xmldom/commit/954370f58c046223faf95ba77efcbc8ce014409d"><code>954370f</code></a> fix: prevent quadratic namespace-map memory consumption via prototype-chain i...</li>
<li><a href="https://github.com/xmldom/xmldom/commit/4430189660b0d380ee9c9ee7550a1358688e8828"><code>4430189</code></a> fix: report not-well-formed end-tag trailing content (GHSA-6h8r-xr42-gp59)</li>
<li><a href="https://github.com/xmldom/xmldom/commit/6c3fb5ffeafe7901ec928ce9010988dd716c94a0"><code>6c3fb5f</code></a> fix: prevent XML injection via unsafe EntityReference name (GHSA-6gmq-8vp8-gcm6)</li>
<li><a href="https://github.com/xmldom/xmldom/commit/3b694872bcb5c7e3cbadba961a4be2488750ce5b"><code>3b69487</code></a> fix: prevent XML injection via unsafe processing instruction target serializa...</li>
<li>Additional commits viewable in <a href="https://github.com/xmldom/xmldom/compare/0.8.13...0.8.15">compare view</a></li>
</ul>
</details>
<details>
<summary>Maintainer changes</summary>
<p>This version was pushed to npm by <a href="https://www.npmjs.com/~karfau">karfau</a>, a new releaser for <code>@​xmldom/xmldom</code> since your current version.</p>
</details>
<br />

Updates `browserslist` from 4.28.4 to 4.28.9
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/browserslist/browserslist/releases">browserslist's releases</a>.</em></p>
<blockquote>
<h2>4.28.9</h2>
<ul>
<li>Improve <code>or</code> parsing performance (by <a href="https://github.com/NotAFlightRisk"><code>@​NotAFlightRisk</code></a>).</li>
</ul>
<h2>4.28.8</h2>
<ul>
<li>Fixed <code>including kaios</code> in baseline queries (by <a href="https://github.com/Jaybhade"><code>@​Jaybhade</code></a>).</li>
</ul>
<h2>4.28.7</h2>
<ul>
<li>Improved parsing performance.</li>
<li>Fixed unbounded memory growth (by <a href="https://github.com/alanturing881"><code>@​alanturing881</code></a>).</li>
<li>Fixed prototype write issue (by <a href="https://github.com/alanturing881"><code>@​alanturing881</code></a>).</li>
</ul>
<h2>4.28.6</h2>
<ul>
<li>Fixed Electron version queries (by <a href="https://github.com/spokodev"><code>@​spokodev</code></a>).</li>
</ul>
<h2>4.28.5</h2>
<ul>
<li>Fixed <code>&gt;</code> and <code>&gt;=</code> queries (by <a href="https://github.com/spokodev"><code>@​spokodev</code></a>).</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/browserslist/browserslist/blob/main/CHANGELOG.md">browserslist's changelog</a>.</em></p>
<blockquote>
<h2>4.28.9</h2>
<ul>
<li>Improve <code>or</code> parsing performance (by <a href="https://github.com/NotAFlightRisk"><code>@​NotAFlightRisk</code></a>).</li>
</ul>
<h2>4.28.8</h2>
<ul>
<li>Fixed <code>including kaios</code> in baseline queries (by <a href="https://github.com/Jaybhade"><code>@​Jaybhade</code></a>).</li>
</ul>
<h2>4.28.7</h2>
<ul>
<li>Improved parsing performance.</li>
<li>Fixed unbounded memory growth (by <a href="https://github.com/alanturing881"><code>@​alanturing881</code></a>).</li>
<li>Fixed prototype write issue (by <a href="https://github.com/alanturing881"><code>@​alanturing881</code></a>).</li>
</ul>
<h2>4.28.6</h2>
<ul>
<li>Fixed Electron version queries (by <a href="https://github.com/spokodev"><code>@​spokodev</code></a>).</li>
</ul>
<h2>4.28.5</h2>
<ul>
<li>Fixed <code>&gt;</code> and <code>&gt;=</code> queries (by <a href="https://github.com/spokodev"><code>@​spokodev</code></a>).</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/browserslist/browserslist/commit/12ed5252dabc14fee4e97b465894b2f90910ca62"><code>12ed525</code></a> Release 4.28.9 version</li>
<li><a href="https://github.com/browserslist/browserslist/commit/b1d8cf9d7a7dc76f6585425a8360218289194297"><code>b1d8cf9</code></a> Update dependencies</li>
<li><a href="https://github.com/browserslist/browserslist/commit/21517b651c915cdbbfb8c122268bc36f5cabb7ef"><code>21517b6</code></a> Improve <code>or</code> parsing performance</li>
<li><a href="https://github.com/browserslist/browserslist/commit/f2f2e6cfb01bb4942941d328737546f4e2ae41ad"><code>f2f2e6c</code></a> Release 4.28.8 version</li>
<li><a href="https://github.com/browserslist/browserslist/commit/d0787c88fa29ba895fea51cfe921232c7b5d1377"><code>d0787c8</code></a> Update dependencies</li>
<li><a href="https://github.com/browserslist/browserslist/commit/fcf8fa9857b30ccdf801a548f5d09d3c4ff0d43f"><code>fcf8fa9</code></a> Merge pull request <a href="https://redirect.github.com/browserslist/browserslist/issues/939">#939</a> from Jaybhade/fix/baseline-kaios-without-downstream</li>
<li><a href="https://github.com/browserslist/browserslist/commit/57ecd64454e9252afdd6a7e76926e13dda48a38c"><code>57ecd64</code></a> fix: support &quot;including kaios&quot; without downstream</li>
<li><a href="https://github.com/browserslist/browserslist/commit/093a0f67bb0becda55235d767b134df3197c54a1"><code>093a0f6</code></a> Update EM banner</li>
<li><a href="https://github.com/browserslist/browserslist/commit/b637868045806d2fba4c24eb0060e4cc8b1db276"><code>b637868</code></a> Release 4.28.7 version</li>
<li><a href="https://github.com/browserslist/browserslist/commit/313f4659b9f985ade89d1d6a54a860371c41cc46"><code>313f465</code></a> Update dependencies</li>
<li>Additional commits viewable in <a href="https://github.com/browserslist/browserslist/compare/4.28.4...4.28.9">compare view</a></li>
</ul>
</details>
<br />

Updates `fast-uri` from 3.1.5 to 3.1.7
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/fastify/fast-uri/releases">fast-uri's releases</a>.</em></p>
<blockquote>
<h2>v3.1.7</h2>
<h2>⚠️ Security Warning</h2>
<p>This is a security release that fixes the following high-severity security advisories:</p>
<ul>
<li><a href="https://github.com/fastify/fast-uri/security/advisories/GHSA-qw65-cvwx-89v3">GHSA-qw65-cvwx-89v3</a> — authority injection via an unvalidated port in <code>serialize()</code></li>
<li><a href="https://github.com/fastify/fast-uri/security/advisories/GHSA-58mr-gqgx-xq4g">GHSA-58mr-gqgx-xq4g</a> — host confusion via unbalanced or misplaced IP-literal brackets</li>
</ul>
<p>Users of the v3.x release line should upgrade to v3.1.7.</p>
<p><strong>Full Changelog</strong>: <a href="https://github.com/fastify/fast-uri/compare/v3.1.6...v3.1.7">https://github.com/fastify/fast-uri/compare/v3.1.6...v3.1.7</a></p>
<h2>v3.1.6</h2>
<h2>⚠️ Security Warning</h2>
<p>This release addresses the following high-severity security advisories:</p>
<ul>
<li><a href="https://github.com/fastify/fast-uri/security/advisories/GHSA-5jgf-p345-68v8">GHSA-5jgf-p345-68v8</a> — host confusion via skipped IDN canonicalization on scheme-relative references</li>
<li><a href="https://github.com/fastify/fast-uri/security/advisories/GHSA-fph4-wmhf-6fwf">GHSA-fph4-wmhf-6fwf</a> — server-side request forgery via repeated hostname percent-decoding</li>
<li><a href="https://github.com/fastify/fast-uri/security/advisories/GHSA-f65p-4m7j-42xc">GHSA-f65p-4m7j-42xc</a> — server-side request forgery via malformed IPv6 normalization</li>
<li><a href="https://github.com/fastify/fast-uri/security/advisories/GHSA-jqff-g426-hqxp">GHSA-jqff-g426-hqxp</a> — host confusion via percent-encoded scheme normalization</li>
</ul>
<p>Users of the v3.x release line should upgrade to v3.1.6.</p>
<p><strong>Full Changelog</strong>: <a href="https://github.com/fastify/fast-uri/compare/v3.1.5...v3.1.6">https://github.com/fastify/fast-uri/compare/v3.1.5...v3.1.6</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/fastify/fast-uri/commit/412e40abd4eb8beabfb952d80abf949a2baf27a3"><code>412e40a</code></a> Bumped v3.1.7</li>
<li><a href="https://github.com/fastify/fast-uri/commit/9f4c943e4d2133e8d78e0941203879216255bb01"><code>9f4c943</code></a> fix: backport port and IP-literal validation to v3.x (<a href="https://redirect.github.com/fastify/fast-uri/issues/216">#216</a>)</li>
<li><a href="https://github.com/fastify/fast-uri/commit/1eb3ce436fe050807caba79f886ab894f485a588"><code>1eb3ce4</code></a> fix: treat unterminated bracket hosts as reg-names again (<a href="https://redirect.github.com/fastify/fast-uri/issues/214">#214</a>)</li>
<li><a href="https://github.com/fastify/fast-uri/commit/6f970b2951fd896aa0f3a7ff28eeb6640c137d33"><code>6f970b2</code></a> Bumped v3.1.6</li>
<li><a href="https://github.com/fastify/fast-uri/commit/d941579a84273ec7e96bde596b1f7a8be447df2a"><code>d941579</code></a> fix: never run IDN canonicalization on bracketed IP literals</li>
<li><a href="https://github.com/fastify/fast-uri/commit/c0f0279cf370cb89ee56b04bbcde2a7afbe81aba"><code>c0f0279</code></a> test: adapt decoded-scheme handler assertion to 3.x (no mailto scheme)</li>
<li><a href="https://github.com/fastify/fast-uri/commit/37f3417c82994279656854f83ce938acd81c3862"><code>37f3417</code></a> Merge commit from fork</li>
<li><a href="https://github.com/fastify/fast-uri/commit/607bfbe953f28a14c2e06ae64aff38c81ca2937f"><code>607bfbe</code></a> Merge commit from fork</li>
<li><a href="https://github.com/fastify/fast-uri/commit/ae92a4c5d8c4b6c9e447f048d5fcbde7eebd5514"><code>ae92a4c</code></a> Merge commit from fork</li>
<li><a href="https://github.com/fastify/fast-uri/commit/444ecdad447db2cc23c4d422acc6f0daa6fa8eef"><code>444ecda</code></a> Merge commit from fork</li>
<li>Additional commits viewable in <a href="https://github.com/fastify/fast-uri/compare/v3.1.5...v3.1.7">compare view</a></li>
</ul>
</details>
<br />

Updates `joi` from 18.2.3 to 18.2.8
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/hapijs/joi/commit/e30b50e242c91ae9f54bf3c3be0e48a03a13cca0"><code>e30b50e</code></a> 18.2.8</li>
<li><a href="https://github.com/hapijs/joi/commit/1c9dede7376d84eeb89e0e4472e519f2dd323a4d"><code>1c9dede</code></a> Merge pull request <a href="https://redirect.github.com/hapijs/joi/issues/3149">#3149</a> from hapijs/chore/optimize-schema-creation</li>
<li><a href="https://github.com/hapijs/joi/commit/cdad986c2a0e5a180cced83eb06f984f6fd52691"><code>cdad986</code></a> chore: optimize schema creation</li>
<li><a href="https://github.com/hapijs/joi/commit/057dff24f9d0e9bf405501ac33618c5425d27484"><code>057dff2</code></a> 18.2.7</li>
<li><a href="https://github.com/hapijs/joi/commit/a14051a8e67982901d7d24f376931aef38f2972b"><code>a14051a</code></a> Merge pull request <a href="https://redirect.github.com/hapijs/joi/issues/3148">#3148</a> from hapijs/chore/optimize-large-arrays</li>
<li><a href="https://github.com/hapijs/joi/commit/62ee0211eefe034fb54ed8cb0616e1f72dc241d3"><code>62ee021</code></a> chore: optimize processing of large arrays</li>
<li><a href="https://github.com/hapijs/joi/commit/883455e9a93e71cbbb259272177efe0bc97253cc"><code>883455e</code></a> Merge pull request <a href="https://redirect.github.com/hapijs/joi/issues/3147">#3147</a> from hapijs/fix/failover-external-interaction</li>
<li><a href="https://github.com/hapijs/joi/commit/8bacc2ab1f53a8dd6fdb44fe69303d8271933dc1"><code>8bacc2a</code></a> fix: inner external shouldn't execute when parent failover applied</li>
<li><a href="https://github.com/hapijs/joi/commit/a4361e7a6c09fa37b5a7d2422c55ec852e821e72"><code>a4361e7</code></a> 18.2.6</li>
<li><a href="https://github.com/hapijs/joi/commit/00e281018b92ec5154e1ed1cdf56742dab2427e7"><code>00e2810</code></a> Merge pull request <a href="https://redirect.github.com/hapijs/joi/issues/3144">#3144</a> from hapijs/chore/add-regression-test</li>
<li>Additional commits viewable in <a href="https://github.com/hapijs/joi/compare/v18.2.3...v18.2.8">compare view</a></li>
</ul>
</details>
<br />

Updates `nanoid` from 3.3.17 to 3.3.18
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/ai/nanoid/releases">nanoid's releases</a>.</em></p>
<blockquote>
<h2>3.3.18</h2>
<ul>
<li>Fixed infinite loop on async for React Native (by <a href="https://github.com/OvergrowthBeards-JB"><code>@​OvergrowthBeards-JB</code></a>).</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/ai/nanoid/blob/3.3.18/CHANGELOG.md">nanoid's changelog</a>.</em></p>
<blockquote>
<h2>3.3.18</h2>
<ul>
<li>Fixed infinite loop on async for React Native (by <a href="https://github.com/OvergrowthBeards-JB"><code>@​OvergrowthBeards-JB</code></a>).</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/ai/nanoid/commit/9ad98052b316c5e707f8098ace509d2ae165e54d"><code>9ad9805</code></a> Release 3.3.18 version</li>
<li><a href="https://github.com/ai/nanoid/commit/55e50a0621ec084b4bb4000ea4e86e1191bd3da8"><code>55e50a0</code></a> Update CI action</li>
<li><a href="https://github.com/ai/nanoid/commit/e10f8d40ce9d1ab47f66d65a16b48086432730d0"><code>e10f8d4</code></a> Update index.native.js (<a href="https://redirect.github.com/ai/nanoid/issues/606">#606</a>)</li>
<li>See full diff in <a href="https://github.com/ai/nanoid/compare/3.3.17...3.3.18">compare view</a></li>
</ul>
</details>
<br />

Updates `js-yaml` from 4.3.1 to 4.3.2
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/nodeca/js-yaml/blob/4.3.2/CHANGELOG.md">js-yaml's changelog</a>.</em></p>
<blockquote>
<h2>4.3.2 - 2026-08-26</h2>
<h3>Changed</h3>
<ul>
<li>[backport] Hard-limit merge sequence size to 100.</li>
</ul>
<h3>Security</h3>
<ul>
<li>[backport] Count empty mappings in merge sequences toward <code>maxTotalMergeKeys</code>
to limit CPU usage, <a href="https://redirect.github.com/nodeca/js-yaml/issues/797">#797</a>.</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/nodeca/js-yaml/commit/79ca68d90f333fbe6d9e42827527e62636200191"><code>79ca68d</code></a> 4.3.2 released</li>
<li><a href="https://github.com/nodeca/js-yaml/commit/d90b6612a5a84385bdcb556c44578eac76dc0f6b"><code>d90b661</code></a> Backport merge limits from v5.4.1</li>
<li>See full diff in <a href="https://github.com/nodeca/js-yaml/compare/4.3.1...4.3.2">compare view</a></li>
</ul>
</details>
<br />


## How it was tested

- [x] Added tests that cover this change
- [x] For a fix: the regression test fails against the unfixed code
- [x] `npm run check` passes locally
- [x] New functions and IPC handlers have comments explaining *why*
- [x] `CHANGELOG.md` updated
- [x] This PR targets `nightly`, not `main`

## AI assistance

- [x] No AI was used on this change
- [ ] AI was used on this change
